### PR TITLE
server: reap queued requests whose client disconnected before admission

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -11372,19 +11372,47 @@ static bool enqueue(server *s, job *j) {
     return true;
 }
 
+/* ZOMBIE REAP (2026-07-20): a client that disconnects while its request is still
+ * QUEUED was invisible until the first write — the job kept its admission slot
+ * through minutes of queueing and then a full prefill emitted into a dead socket.
+ * Observed live (GB10 fleet): 4 such leaked in-flight requests halved cont-batch
+ * admission capacity, every new first-turn request queued 110-224s behind them and
+ * its client also gave up — a self-feeding clog with requests_failed=0 the whole
+ * time.  Detect the peer's orderly-shutdown FIN with a zero-byte MSG_PEEK before
+ * spending ANY engine work: recv()==0 -> peer closed; EAGAIN or pending bytes ->
+ * alive (the probe never consumes, so a slow-but-connected client is never
+ * false-positived). */
+static void job_finish(job *j);   /* defined below; needed by the reap sites */
+
+static bool client_disconnected(int fd) {
+    char b;
+    ssize_t r = recv(fd, &b, 1, MSG_PEEK | MSG_DONTWAIT);
+    return r == 0;
+}
+
 static job *dequeue(server *s) {
-    pthread_mutex_lock(&s->mu);
-    while (!s->head && !s->stopping) pthread_cond_wait(&s->cv, &s->mu);
-    if (!s->head) {
+    for (;;) {
+        pthread_mutex_lock(&s->mu);
+        while (!s->head && !s->stopping) pthread_cond_wait(&s->cv, &s->mu);
+        if (!s->head) {
+            pthread_mutex_unlock(&s->mu);
+            return NULL;
+        }
+        job *j = s->head;
+        s->head = j->next;
+        if (!s->head) s->tail = NULL;
         pthread_mutex_unlock(&s->mu);
-        return NULL;
+        j->next = NULL;
+        if (client_disconnected(j->fd)) {
+            server_log(DS4_LOG_WARNING,
+                       "ds4-server: reaped queued request: client disconnected before admission "
+                       "(prompt=%d tokens never prefilled)", j->req.prompt.len);
+            j->outcome = JOB_OUT_FAILED;
+            job_finish(j);
+            continue;
+        }
+        return j;
     }
-    job *j = s->head;
-    s->head = j->next;
-    if (!s->head) s->tail = NULL;
-    pthread_mutex_unlock(&s->mu);
-    j->next = NULL;
-    return j;
 }
 
 /* ---- W3: request-coalescing ------------------------------------------------
@@ -11532,6 +11560,14 @@ static int coalesce_gather(server *s, job **out, int cap, int wait_ms, int max_t
             s->head = g->next;
             if (!s->head) s->tail = NULL;
             g->next = NULL;
+            if (client_disconnected(g->fd)) {   /* zombie reap — same gate as dequeue() */
+                server_log(DS4_LOG_WARNING,
+                           "ds4-server: reaped queued request: client disconnected before batch gather "
+                           "(prompt=%d tokens never prefilled)", g->req.prompt.len);
+                g->outcome = JOB_OUT_FAILED;
+                job_finish(g);
+                continue;
+            }
             tok_total += job_tok_footprint(s, g);
             out[n++] = g;
             continue;
@@ -12060,12 +12096,24 @@ static int cont_admit(void *ud, ds4_cont_request *req) {
          * admits (return 0) so it stays at the head and is served next -- the
          * same FIFO discipline coalesce_gather uses, so nothing is starved. */
         pthread_mutex_lock(&s->mu);
-        if (s->head && job_is_batchable(&s->head->req) &&
-            s->head->req.prompt.len > 0 && s->head->req.prompt.len <= cs->seq_cap) {
-            j = s->head;
-            s->head = j->next;
-            if (!s->head) s->tail = NULL;
-            j->next = NULL;
+        for (;;) {
+            if (s->head && job_is_batchable(&s->head->req) &&
+                s->head->req.prompt.len > 0 && s->head->req.prompt.len <= cs->seq_cap) {
+                j = s->head;
+                s->head = j->next;
+                if (!s->head) s->tail = NULL;
+                j->next = NULL;
+                if (client_disconnected(j->fd)) {   /* zombie reap — same gate as dequeue() */
+                    server_log(DS4_LOG_WARNING,
+                               "ds4-server: reaped queued request: client disconnected before cont admit "
+                               "(prompt=%d tokens never prefilled)", j->req.prompt.len);
+                    j->outcome = JOB_OUT_FAILED;
+                    job_finish(j);
+                    j = NULL;
+                    continue;                       /* zombie freed a spot — try the next head */
+                }
+            }
+            break;
         }
         pthread_mutex_unlock(&s->mu);
         if (!j) return 0;


### PR DESCRIPTION
**Bug.** The server only notices a dead client on the first socket write (`client_gone` is set in the send paths). A request whose client disconnects while still QUEUED — proxy timeout, Ctrl-C, crashed caller — keeps its FIFO position, counts in `requests_inflight`, and is eventually admitted to burn a full prefill emitting into a dead socket. Under continuous batching it compounds: each abandoned request holds an admission slot, queue latency grows for live traffic, more clients time out and abandon, minting more zombies.

Observed live on a GB10 (v0.3.0, 1M-ctx ship config, DSpark drafter, no-mtp): 4 leaked in-flight requests (`started 81 / completed 77 / failed 0`), successive first-turn requests queueing 110s → 224s before their clients gave up — a self-feeding clog with `failed=0` throughout, i.e. an outage that presents as perfect health. Only a restart cleared it.

**Fix.** `client_disconnected(fd)` — a zero-byte `recv(MSG_PEEK|MSG_DONTWAIT)`; only `== 0` (peer FIN) is positive, `EAGAIN`/pending-bytes mean alive, so a slow-but-connected client can never be false-positived and no request data is ever consumed — gates all three points a job leaves the FIFO: worker `dequeue()`, static `coalesce_gather()`, and continuous `cont_admit()`. A dead job finishes immediately through the existing `job_finish()`/`JOB_OUT_FAILED` machinery: logged (`reaped queued request: client disconnected before <site> (prompt=N tokens never prefilled)`), visible in `/metrics` as `outcome=failed`, zero engine work spent.

**Verification** (reproducible): saturate all `max_seq` banks with long generations, queue one more request, kill its client after 2s. The zombie is reaped at cont admit the moment a bank frees: `9 started = 8 completed + 1 failed, 0 inflight`, and the reap line confirms nothing was prefilled. Running in production on two GB10s since.

(Same fleet as the ds4-bench 32768-frontier report and the v0.3 context-frontier replication numbers posted on the forum.)
