### PR TITLE
Reuse the KV prefix in thinking mode on the continuous path

### DIFF
--- a/ds4_server.c
+++ b/ds4_server.c
@@ -11768,28 +11768,63 @@ static void warm_rec_invalidate(server *s, int bank) {
     warm_records_gauge_refresh(s);
 }
 
+/* Append the committed generation (tokens[0..n-2]) to b as detokenized text. */
+static void cont_append_committed_text(server *s, buf *b, const int *tokens, int n) {
+    for (int k = 0; k < n - 1; k++) {
+        size_t pl = 0;
+        char *piece = ds4_token_text(s->engine, tokens[k], &pl);
+        if (piece) { buf_append(b, piece, pl); free(piece); }
+    }
+}
+
 /* Retire job j's bank at on_done: rebuild the record a follow-up request
  * extending this conversation will byte-prefix-match.  The engine never
  * forwards the final sample, so the committed generation is tokens[0..n-2]
- * uniformly (EOS/budget/abort, and mode-2's per-step commits).  Thinking rows
- * retire INVALID -- the next rendering omits reasoning, so a raw text key
- * would be wrong.  Tool turns stay matchable because the next renderer
- * replays the remembered raw_dsml verbatim.  Stop-finish rows build records
- * that simply never match (committed post-stop tokens) -- harmless. */
-static void cont_warm_retire(server *s, job *j, const int *tokens, int n) {
+ * uniformly (EOS/budget/abort, and mode-2's per-step commits).  Tool turns
+ * stay matchable because the next renderer replays the remembered raw_dsml
+ * verbatim.  Stop-finish rows build records that simply never match
+ * (committed post-stop tokens) -- harmless.
+ *
+ * Thinking rows need a key the NEXT rendering will actually reproduce, and
+ * prompt_preserves_reasoning already says which one that is:
+ *
+ *   - preserved (the history carries tool context, so render_chat_prompt_text
+ *     replays the reasoning): the raw key is what comes back, retire normally.
+ *   - otherwise: key on the VISIBLE transcript, as the session path already
+ *     does (build_toolless_thinking_visible_text).  The payload stays the
+ *     bank's committed frontier, which cont_warm_pick pairs with a tokenized
+ *     suffix, so hidden reasoning stays in KV and is never re-prefilled.
+ *
+ * Same gates as should_remember_thinking_checkpoint(): chat only, tool-less,
+ * a clean finish, and a closed thinking block.  Anything else retires without
+ * a record, as before. */
+static void cont_warm_retire(server *s, job *j, const int *tokens, int n,
+                             int finish) {
     if (!s->warm || j->cont_bank < 0 || j->cont_bank >= s->batch_ctx_max_seq) return;
     const int bank = j->cont_bank;
     warm_rec_invalidate(s, bank);
     s->warm[bank].last_use = ++s->warm_clock;
     if (!tokens || n <= 0) return;
     if (!j->req.prompt_text || !j->req.prompt_text[0]) return;
-    if (ds4_think_mode_enabled(j->req.think_mode)) return;
+
     buf tb = {0};
-    buf_puts(&tb, j->req.prompt_text);
-    for (int k = 0; k < n - 1; k++) {
-        size_t pl = 0;
-        char *piece = ds4_token_text(s->engine, tokens[k], &pl);
-        if (piece) { buf_append(&tb, piece, pl); free(piece); }
+    if (!ds4_think_mode_enabled(j->req.think_mode) ||
+        j->req.prompt_preserves_reasoning)
+    {
+        buf_puts(&tb, j->req.prompt_text);
+        cont_append_committed_text(s, &tb, tokens, n);
+    } else {
+        if (j->req.kind != REQ_CHAT || j->req.has_tools || !finish) return;
+        buf gen = {0};
+        cont_append_committed_text(s, &gen, tokens, n);
+        const char *close = gen.ptr ? strstr(gen.ptr, "</think>") : NULL;
+        char *visible = close ? build_toolless_thinking_visible_text(
+                                    &j->req, close + strlen("</think>"))
+                              : NULL;
+        buf_free(&gen);
+        if (!visible) return;          /* not keyable -- retire without a record */
+        buf_puts(&tb, visible);
+        free(visible);
     }
     s->warm[bank].text = tb.ptr;
     s->warm[bank].len = tb.len;
@@ -12522,7 +12557,7 @@ static void cont_on_done(void *ud, void *user, const int *tokens, int n, int fin
     job *j = user;
     /* A2a: retire the bank this job occupied (rebuild its warm record) and drop
      * the warm effective prompt -- the engine is done reading it. */
-    cont_warm_retire(cs->s, j, tokens, n);
+    cont_warm_retire(cs->s, j, tokens, n, finish);
     ds4_tokens_free(&j->warm_prompt);
     memset(&j->warm_prompt, 0, sizeof(j->warm_prompt));
     /* v0.2.x observability: merge the engine's per-sequence stats (valid only


### PR DESCRIPTION
I've been chasing this issue after playing with v0.2.3 yesterday and v0.4.0 today. My sessions on pi and Open WebUI were clearly re-processing the whole conversation on each turn.

This PR addresses the issue following an approach already used upstream in antirez/ds4, which this fork's newer continuous-batching path never inherited. I think it also explains Entrpi/ds4-on-spark#4, opened earlier today with little detail and no logs.

Code was prepared with assistance from Claude, but led and reviewed by me. It's worth a second look, though.

## What happens today

On the continuous batching path, a conversation in thinking mode re-prefills its entire prompt on every single turn. The prefix cache never hits.

It shows up in the serve log as an unbroken run of cold admissions, where the conversation only ever grows by a few tokens per turn:

```
cont admit bank=1 pos_base=0 suffix=29234 wall=41.44s
cont admit bank=1 pos_base=0 suffix=29308 wall=40.57s
cont admit bank=1 pos_base=0 suffix=31022 wall=43.10s
```

`pos_base=0` on every turn means nothing was reused. The same conversation sent to the non-thinking `deepseek-chat` alias reuses normally:

```
partial fork admit src=0 dst=1 cut=29123 suffix=145
cont admit bank=1 pos_base=29056 suffix=212 wall=0.80s
```

That is 40.86s versus 0.80s for turn two, on byte-identical prompts, with only the thinking mode differing. Measured on a DGX Spark (GB10) at ctx 524288 with a real coding agent whose preamble is 29,234 tokens.

There is a second symptom with the same cause. A bank that never gets a warm record never becomes reuse-trustworthy, so it is never written to the disk KV cache either, not even on a clean shutdown. With `--kv-disk-dir` configured and a 64 GiB budget, the directory stayed completely empty across a full day of thinking-mode traffic and four clean stops. This is very likely what Entrpi/ds4-on-spark#4 ("nothing is getting written to disk, and it's causing a lot of prompt reprocessing") is actually reporting: two symptoms, one cause.

## Cause

`cont_warm_retire()` in `ds4_server.c` bailed out for every thinking row:

```c
if (ds4_think_mode_enabled(j->req.think_mode)) return;
```

so no warm record was ever built and `cont_warm_pick()` had nothing to match.

The session path already solves this problem with visible-live checkpoints (`build_toolless_thinking_visible_text`, `thinking_live_visible_prefix_prompt`): it keys the checkpoint on the transcript the client will replay, while the payload stays the exact sampled frontier including the hidden reasoning. The continuous batching path, added later, never inherited that idea.

It is not a recent regression. `git tag --contains` puts the guard in `v0.1.0` onward.

## The fix

A raw text key is only wrong when the next rendering drops the reasoning bytes, and `prompt_preserves_reasoning` already tells us when that happens:

- **Reasoning preserved** (the history carries tool context, so `render_chat_prompt_text` replays it): the raw key is exactly what comes back, so retire normally.
- **Otherwise**: key the record on the visible transcript, exactly as the session path does. The payload stays the bank's committed frontier, which `cont_warm_pick` already pairs with a tokenized text suffix, so the hidden reasoning stays resident in KV and is never re-prefilled.

The visible-key branch takes the same conservative gates as `should_remember_thinking_checkpoint()`: chat only, tool-less, a clean finish and a closed thinking block. Anything that does not qualify retires without a record, exactly as before.

48 insertions, 13 deletions, one file.

## Testing

Machine: NVIDIA DGX Spark (GB10, sm_121, 128 GB unified memory), CUDA backend, driver 580.159.03 / CUDA 13.0, Ubuntu.
Model: `DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf` (IQ2_XXS/Q2K experts, Q8 dense), DSpark drafter armed, ctx 524288.
Build: `make cuda CUDA_ARCH=sm_121` with `-DDS4_CUDA_SPARK_HBM_CACHE=1`.

```sh
DS4_TEST_MODEL=.../DeepSeek-V4-Flash-...-imatrix.gguf make test
```

passes in full against the patched build, with the model loaded and the GPU otherwise idle (4m28s). Tensor equivalence is exact across all five cases: `top1_mismatch=0 worst_rms=0 worst_max_abs=0`.

Turn two now reuses in every thinking shape that was previously broken:

| Scenario | Before | After |
|---|---|---|
| thinking, no tools | `pos_base=0` | `fork admit cached=3419 suffix=9` |
| thinking, 35 tools | `pos_base=0` | `partial truncate admit cut=5267 suffix=21` |
| thinking, reasoning echoed back | `pos_base=0` | `warm admit cached=3443 suffix=9` |
| non-thinking (control) | reuses | reuses, unchanged |

The disk tier now receives thinking-mode checkpoints, which it never did before:

```
kv cache stored tokens=6827 reason=bank-shutdown size=51.42 MiB save=11.9 ms bank persisted bank=0 tokens=6827
kv cache stored tokens=8681 reason=bank-shutdown size=59.18 MiB save=12.7 ms bank persisted bank=1 tokens=8681
```

Correctness was checked rather than assumed: a needle placed deep in the prompt and asked for only on the reused turn (`pos_base=8448`, so genuinely served from reused KV) came back exact.

### Verified live on the serving stack

The numbers above swap the model id to isolate thinking mode. This is the cleaner comparison: the same real coding agent, the same 29,244 token preamble, thinking mode on both runs, only the binary differs.

Before, on the stock build:

```
turn 1  cont admit bank=0 pos_base=0 suffix=29244 wall=45.82s
turn 2  cont admit bank=0 pos_base=0 suffix=29321 wall=39.40s
```

After, with the patch, same client and same conversation shape:

```
turn 1  cont admit bank=0 pos_base=0 suffix=29244 wall=40.61s
turn 2  partial fork admit src=0 dst=1 cut=29133 suffix=171
        cont admit bank=1 pos_base=29056 suffix=248 wall=0.80s
turn 3  partial truncate admit bank=1 cut=29192 suffix=355
        cont admit bank=1 pos_base=29184 suffix=363 wall=0.93s
```

Turn one is identical to the token, as it should be. Turn two goes from 39.40s to 0.80s, and reuse holds as the conversation grows, through both admit paths (fork into a free bank, then truncate in place). This client sends 35 tool schemas, so it exercises the `prompt_preserves_reasoning` branch; the tool-less visible-transcript branch is covered by the table above.

## Notes on the other regression tracks

`make cpu` fails on this branch, but it already fails identically at the unmodified base commit (`4880163`), so it is not something this change introduced:

```
ds4.c:28903: error: unknown type name 'ds4_gpu_graph'
ds4.c:28903: error: unknown type name 'payload_region'
```

I did not run the `ds4-bench` speed sweep. This change touches server-side warm record bookkeeping at job retirement, not any inference backend or kernel: the only added work is one detokenization pass over the generated tokens for thinking rows, which the non-thinking path already performed on every turn. Happy to run a before/after sweep if you would like it on the record.

## Scope and limits

- Streaming, mid-stream client aborts and tool round-trips were all verified separately and were never part of this bug.
- Turns that stop on `length` retire without a record, matching the session path's existing conservatism. Loosening that is a separate question.
- The engine still validates every warm admit against its own committed history, so a stale or mismatched record degrades to a cold reset rather than serving wrong state.
