### PR TITLE
Reasoning effort: implement the three levels the 0731 model card documents

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -62,15 +62,27 @@
 #define DS4_DEFAULT_COMPRESS_ROPE_FREQ_BASE (160000.0f)
 #define DS4_DEFAULT_ROPE_ORIG_CTX       UINT64_C(65536)
 
-static const char DS4_REASONING_EFFORT_MAX_PREFIX[] =
+/* Reasoning-effort prefixes, verbatim from the DeepSeek-V4-Flash-0731 reference
+ * encoder (encoding/encoding_dsv4.py, REASONING_EFFORT_PROMPTS).  Upstream's
+ * "low" is the empty string, so it needs no constant here.  Both are injected
+ * at the very start of the conversation, ahead of the system message, which is
+ * where the reference encoder puts them (render_message: index == 0 and
+ * thinking_mode == "thinking"). */
+static const char DS4_REASONING_EFFORT_HIGH_PREFIX[] =
     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
 
-/* DeepSeek recommends Think Max only with at least a 384K-token context window.
- * Below that size we keep ordinary thinking to avoid injecting a prompt that
- * asks for a reasoning budget the allocated context is not meant to hold. */
-#define DS4_THINK_MAX_MIN_CONTEXT 393216u
+static const char DS4_REASONING_EFFORT_MAX_PREFIX[] =
+    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
+
+/* DeepSeek recommends a 384K-token output budget for BOTH the high and max
+ * effort levels, so below that context size we fall back to the prefix-free
+ * low level rather than injecting a prompt that asks for a reasoning budget
+ * the allocated context is not meant to hold. */
+#define DS4_THINK_EFFORT_MIN_CONTEXT 393216u
 
 static bool ds4_backend_uses_graph(ds4_backend backend) {
     return backend == DS4_BACKEND_METAL || backend == DS4_BACKEND_CUDA;
@@ -23043,8 +23055,11 @@ static void encode_chat_prompt(
         ds4_think_mode   think_mode,
         token_vec       *out) {
     token_vec_push(out, vocab->bos_id);
-    if (think_mode == DS4_THINK_MAX) {
-        bpe_tokenize_text(vocab, DS4_REASONING_EFFORT_MAX_PREFIX, out);
+    {
+        /* Effort prefix ahead of the system message, matching the reference
+         * encoder's placement.  LOW and NONE contribute nothing. */
+        const char *effort = ds4_think_effort_prefix(think_mode);
+        if (effort[0]) bpe_tokenize_text(vocab, effort, out);
     }
     if (system && system[0]) {
         bpe_tokenize_text(vocab, system, out);
@@ -23135,8 +23150,9 @@ void ds4_encode_chat_prompt(
     encode_chat_prompt(&e->vocab, system, prompt ? prompt : "", think_mode, out);
 }
 
-void ds4_chat_append_max_effort_prefix(ds4_engine *e, ds4_tokens *tokens) {
-    bpe_tokenize_text(&e->vocab, DS4_REASONING_EFFORT_MAX_PREFIX, tokens);
+void ds4_chat_append_effort_prefix(ds4_engine *e, ds4_tokens *tokens, ds4_think_mode mode) {
+    const char *effort = ds4_think_effort_prefix(mode);
+    if (effort[0]) bpe_tokenize_text(&e->vocab, effort, tokens);
 }
 
 void ds4_chat_append_message(ds4_engine *e, ds4_tokens *tokens, const char *role, const char *content) {
@@ -27959,29 +27975,48 @@ const char *ds4_backend_name(ds4_backend backend) {
 }
 
 bool ds4_think_mode_enabled(ds4_think_mode mode) {
-    return mode == DS4_THINK_HIGH || mode == DS4_THINK_MAX;
+    return mode != DS4_THINK_NONE;
 }
 
 const char *ds4_think_mode_name(ds4_think_mode mode) {
     switch (mode) {
     case DS4_THINK_NONE: return "none";
+    case DS4_THINK_LOW:  return "low";
     case DS4_THINK_HIGH: return "high";
     case DS4_THINK_MAX:  return "max";
     }
     return "unknown";
 }
 
+const char *ds4_think_high_prefix(void) {
+    return DS4_REASONING_EFFORT_HIGH_PREFIX;
+}
+
 const char *ds4_think_max_prefix(void) {
     return DS4_REASONING_EFFORT_MAX_PREFIX;
 }
 
-uint32_t ds4_think_max_min_context(void) {
-    return DS4_THINK_MAX_MIN_CONTEXT;
+const char *ds4_think_effort_prefix(ds4_think_mode mode) {
+    switch (mode) {
+    case DS4_THINK_HIGH: return DS4_REASONING_EFFORT_HIGH_PREFIX;
+    case DS4_THINK_MAX:  return DS4_REASONING_EFFORT_MAX_PREFIX;
+    case DS4_THINK_NONE:
+    case DS4_THINK_LOW:
+        break;
+    }
+    return "";
+}
+
+uint32_t ds4_think_effort_min_context(void) {
+    return DS4_THINK_EFFORT_MIN_CONTEXT;
 }
 
 ds4_think_mode ds4_think_mode_for_context(ds4_think_mode mode, int ctx_size) {
-    if (mode == DS4_THINK_MAX && (uint32_t)(ctx_size > 0 ? ctx_size : 0) < DS4_THINK_MAX_MIN_CONTEXT) {
-        return DS4_THINK_HIGH;
+    const uint32_t ctx = (uint32_t)(ctx_size > 0 ? ctx_size : 0);
+    if ((mode == DS4_THINK_HIGH || mode == DS4_THINK_MAX) &&
+        ctx < DS4_THINK_EFFORT_MIN_CONTEXT)
+    {
+        return DS4_THINK_LOW;
     }
     return mode;
 }

--- a/ds4.h
+++ b/ds4.h
@@ -20,8 +20,22 @@ typedef enum {
     DS4_BACKEND_CPU,
 } ds4_backend;
 
+/* Reasoning effort, mirroring the three levels the DeepSeek-V4-Flash-0731 model
+ * card and its reference encoder (encoding/encoding_dsv4.py) define.  All three
+ * are PROMPT PREFIXES prepended at the very start of the conversation in
+ * thinking mode -- the checkpoint carries no per-level control token, and its
+ * embedded chat template has no reasoning_effort at all, so this is the whole
+ * mechanism, not an approximation of one.
+ *   DS4_THINK_LOW   upstream "low"  -- adds nothing.  The reference encoder's
+ *                                      DEFAULT_REASONING_EFFORT, and ours.
+ *   DS4_THINK_HIGH  upstream "high" -- the "Absolute maximum" prefix.
+ *   DS4_THINK_MAX   upstream "max"  -- the "Beyond maximum" prefix.
+ * Before this change the engine exposed only two non-zero levels and labelled
+ * them one tier too low: what it called MAX emitted upstream's *high* string,
+ * and upstream's max had no representation at all. */
 typedef enum {
     DS4_THINK_NONE,
+    DS4_THINK_LOW,
     DS4_THINK_HIGH,
     DS4_THINK_MAX,
 } ds4_think_mode;
@@ -165,8 +179,11 @@ int ds4_engine_model_id(ds4_engine *e);
 const char *ds4_backend_name(ds4_backend backend);
 bool ds4_think_mode_enabled(ds4_think_mode mode);
 const char *ds4_think_mode_name(ds4_think_mode mode);
+const char *ds4_think_high_prefix(void);
 const char *ds4_think_max_prefix(void);
-uint32_t ds4_think_max_min_context(void);
+/* The prefix a mode injects, or "" for NONE/LOW.  Never NULL. */
+const char *ds4_think_effort_prefix(ds4_think_mode mode);
+uint32_t ds4_think_effort_min_context(void);
 ds4_think_mode ds4_think_mode_for_context(ds4_think_mode mode, int ctx_size);
 /* Uses the active model shape selected by ds4_engine_open(); call after opening
  * the GGUF so Flash/Pro dimensions are known. */
@@ -528,7 +545,7 @@ void ds4_encode_chat_prompt(
         const char *prompt,
         ds4_think_mode think_mode,
         ds4_tokens *out);
-void ds4_chat_append_max_effort_prefix(ds4_engine *e, ds4_tokens *tokens);
+void ds4_chat_append_effort_prefix(ds4_engine *e, ds4_tokens *tokens, ds4_think_mode mode);
 void ds4_chat_append_message(ds4_engine *e, ds4_tokens *tokens, const char *role, const char *content);
 void ds4_chat_append_assistant_prefix(ds4_engine *e, ds4_tokens *tokens, ds4_think_mode think_mode);
 

--- a/ds4_agent.c
+++ b/ds4_agent.c
@@ -567,7 +567,7 @@ static agent_config parse_options(int argc, char **argv) {
             .temperature = DS4_DEFAULT_TEMPERATURE,
             .top_p = DS4_DEFAULT_TOP_P,
             .min_p = DS4_DEFAULT_MIN_P,
-            .think_mode = DS4_THINK_HIGH,
+            .think_mode = DS4_THINK_LOW,
         },
     };
 
@@ -624,9 +624,9 @@ static agent_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--seed")) {
             c.gen.seed = parse_u64(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--think")) {
-            c.gen.think_mode = DS4_THINK_HIGH;
+            c.gen.think_mode = DS4_THINK_LOW;
         } else if (!strcmp(arg, "--think-max")) {
-            c.gen.think_mode = DS4_THINK_MAX;
+            c.gen.think_mode = DS4_THINK_HIGH;
         } else if (!strcmp(arg, "--nothink")) {
             c.gen.think_mode = DS4_THINK_NONE;
         } else if (!strcmp(arg, "--backend")) {
@@ -3847,9 +3847,7 @@ static bool agent_kv_save_path(agent_worker *w, const char *path,
 
 static void agent_worker_build_system_tokens(agent_worker *w, ds4_tokens *out) {
     ds4_chat_begin(w->engine, out);
-    if (w->cfg->gen.think_mode == DS4_THINK_MAX &&
-        effective_think_mode(w->cfg) == DS4_THINK_MAX)
-        ds4_chat_append_max_effort_prefix(w->engine, out);
+    ds4_chat_append_effort_prefix(w->engine, out, effective_think_mode(w->cfg));
     agent_append_system_prompt(w->engine, out, w->cfg->gen.system);
 }
 

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -334,8 +334,8 @@ static ds4_think_mode cli_effective_think_mode(const cli_generation_options *gen
 }
 
 static bool cli_think_max_downgraded(const cli_generation_options *gen) {
-    return gen->think_mode == DS4_THINK_MAX &&
-           cli_effective_think_mode(gen) != DS4_THINK_MAX;
+    return gen->think_mode == DS4_THINK_HIGH &&
+           cli_effective_think_mode(gen) != DS4_THINK_HIGH;
 }
 
 static void cli_warn_think_max_downgraded(const cli_generation_options *gen, const char *name) {
@@ -344,7 +344,7 @@ static void cli_warn_think_max_downgraded(const cli_generation_options *gen, con
         DS4_LOG_WARNING,
         "ds4: warning: %s needs --ctx >= %u; ctx=%d uses normal thinking instead\n",
         name,
-        ds4_think_max_min_context(),
+        ds4_think_effort_min_context(),
         gen->ctx_size);
 }
 
@@ -1238,10 +1238,12 @@ static void tokens_remove(ds4_tokens *dst, int pos, int n) {
  * prefix lives after BOS, before any system/developer text, which mirrors the
  * API rendering path.  Changing it invalidates the session because every later
  * token position would otherwise refer to the wrong prefix. */
-static void repl_chat_apply_max_prefix(ds4_engine *engine, repl_chat *chat, bool enable) {
+static void repl_chat_apply_effort_prefix(ds4_engine *engine, repl_chat *chat,
+                                          ds4_think_mode mode) {
+    const bool enable = ds4_think_effort_prefix(mode)[0] != '\0';
     if (enable && chat->max_prefix_tokens == 0) {
         ds4_tokens prefix = {0};
-        ds4_chat_append_max_effort_prefix(engine, &prefix);
+        ds4_chat_append_effort_prefix(engine, &prefix, mode);
         tokens_insert(&chat->transcript, 1, &prefix);
         chat->max_prefix_tokens = prefix.len;
         ds4_tokens_free(&prefix);
@@ -1268,8 +1270,7 @@ static int repl_chat_create_session(ds4_engine *engine, repl_chat *chat, int ctx
 static int repl_chat_init(ds4_engine *engine, repl_chat *chat, const cli_config *cfg) {
     memset(chat, 0, sizeof(*chat));
     ds4_chat_begin(engine, &chat->transcript);
-    repl_chat_apply_max_prefix(engine, chat,
-                               cli_effective_think_mode(&cfg->gen) == DS4_THINK_MAX);
+    repl_chat_apply_effort_prefix(engine, chat, cli_effective_think_mode(&cfg->gen));
     if (cfg->gen.system && cfg->gen.system[0]) {
         ds4_chat_append_message(engine, &chat->transcript, "system", cfg->gen.system);
     }
@@ -1302,7 +1303,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
 
     ds4_think_mode think_mode = ds4_think_mode_for_context(cfg->gen.think_mode,
                                                            chat->ctx_size);
-    repl_chat_apply_max_prefix(engine, chat, think_mode == DS4_THINK_MAX);
+    repl_chat_apply_effort_prefix(engine, chat, think_mode == DS4_THINK_HIGH);
     const int rollback_len = chat->transcript.len;
     ds4_chat_append_message(engine, &chat->transcript, "user", user_text);
     ds4_chat_append_assistant_prefix(engine, &chat->transcript, think_mode);
@@ -1474,19 +1475,19 @@ static int run_repl(ds4_engine *engine, cli_config *cfg) {
         if (!strcmp(cmd, "/help")) {
             print_repl_help();
         } else if (!strcmp(cmd, "/think")) {
-            cfg->gen.think_mode = DS4_THINK_HIGH;
-            repl_chat_apply_max_prefix(engine, &chat, false);
+            cfg->gen.think_mode = DS4_THINK_LOW;
+            repl_chat_apply_effort_prefix(engine, &chat, false);
             puts("Thinking mode: high.");
         } else if (!strcmp(cmd, "/think-max")) {
-            cfg->gen.think_mode = DS4_THINK_MAX;
+            cfg->gen.think_mode = DS4_THINK_HIGH;
             bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
-                                                     chat.ctx_size) == DS4_THINK_MAX;
-            repl_chat_apply_max_prefix(engine, &chat, active);
+                                                     chat.ctx_size) == DS4_THINK_HIGH;
+            repl_chat_apply_effort_prefix(engine, &chat, active);
             cli_warn_think_max_downgraded(&cfg->gen, "/think-max");
             printf("Thinking mode: %s.\n", active ? "max" : "high (ctx below 393216)");
         } else if (!strcmp(cmd, "/nothink")) {
             cfg->gen.think_mode = DS4_THINK_NONE;
-            repl_chat_apply_max_prefix(engine, &chat, false);
+            repl_chat_apply_effort_prefix(engine, &chat, false);
             puts("Thinking mode: none.");
         } else if (!strncmp(cmd, "/power", 6) && (cmd[6] == '\0' || isspace((unsigned char)cmd[6]))) {
             char *arg = trim_inplace(cmd + 6);
@@ -1516,8 +1517,8 @@ static int run_repl(ds4_engine *engine, cli_config *cfg) {
                     break;
                 }
                 bool active = ds4_think_mode_for_context(cfg->gen.think_mode,
-                                                         chat.ctx_size) == DS4_THINK_MAX;
-                repl_chat_apply_max_prefix(engine, &chat, active);
+                                                         chat.ctx_size) == DS4_THINK_HIGH;
+                repl_chat_apply_effort_prefix(engine, &chat, active);
                 cli_warn_think_max_downgraded(&cfg->gen, "/ctx");
             }
         } else if (!strcmp(cmd, "/quit") || !strcmp(cmd, "/exit")) {
@@ -1619,7 +1620,7 @@ static cli_config parse_options(int argc, char **argv) {
             .top_p = DS4_DEFAULT_TOP_P,
             .min_p = DS4_DEFAULT_MIN_P,
             .dump_logprobs_top_k = 20,
-            .think_mode = DS4_THINK_HIGH,
+            .think_mode = DS4_THINK_LOW,
         },
     };
 
@@ -1731,9 +1732,9 @@ static cli_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--imatrix-max-tokens")) {
             c.gen.imatrix_max_tokens = parse_int(need_arg(&i, argc, argv, arg), arg);
         } else if (!strcmp(arg, "--think")) {
-            c.gen.think_mode = DS4_THINK_HIGH;
+            c.gen.think_mode = DS4_THINK_LOW;
         } else if (!strcmp(arg, "--think-max")) {
-            c.gen.think_mode = DS4_THINK_MAX;
+            c.gen.think_mode = DS4_THINK_HIGH;
         } else if (!strcmp(arg, "--nothink")) {
             c.gen.think_mode = DS4_THINK_NONE;
         } else if (!strcmp(arg, "--head-test")) {

--- a/ds4_eval.c
+++ b/ds4_eval.c
@@ -1545,7 +1545,7 @@ static eval_config parse_options(int argc, char **argv) {
         .soft_limit_reply_budget = 1024,
         .hard_limit_reply_budget = 512,
         .soft_limit_think_close_rank = 3,
-        .think_mode = DS4_THINK_HIGH,
+        .think_mode = DS4_THINK_LOW,
     };
 
     for (int i = 1; i < argc; i++) {
@@ -1626,9 +1626,9 @@ static eval_config parse_options(int argc, char **argv) {
         } else if (!strcmp(arg, "--warm-weights")) {
             c.warm_weights = true;
         } else if (!strcmp(arg, "--think")) {
-            c.think_mode = DS4_THINK_HIGH;
+            c.think_mode = DS4_THINK_LOW;
         } else if (!strcmp(arg, "--think-max")) {
-            c.think_mode = DS4_THINK_MAX;
+            c.think_mode = DS4_THINK_HIGH;
         } else if (!strcmp(arg, "--nothink")) {
             c.think_mode = DS4_THINK_NONE;
         } else if (!strcmp(arg, "--plain")) {
@@ -2434,8 +2434,8 @@ static int eval_auto_context_size(ds4_engine *engine,
     int ctx = EVAL_MAX_CONTEXT;
     int max_prompt = 0;
     int max_case = -1;
-    const int min_ctx = cfg->think_mode == DS4_THINK_MAX ?
-                        (int)ds4_think_max_min_context() : 1;
+    const int min_ctx = cfg->think_mode == DS4_THINK_HIGH ?
+                        (int)ds4_think_effort_min_context() : 1;
 
     /* Think Max downgrades to normal thinking under its minimum context.  Size
      * the prompts iteratively so the prompt tokenizer sees the same effective
@@ -2460,13 +2460,13 @@ static int eval_auto_context_size(ds4_engine *engine,
 }
 
 static void eval_warn_think_max_downgraded(const eval_config *cfg) {
-    if (cfg->think_mode != DS4_THINK_MAX ||
-        ds4_think_mode_for_context(cfg->think_mode, cfg->ctx_size) == DS4_THINK_MAX) {
+    if (cfg->think_mode != DS4_THINK_HIGH ||
+        ds4_think_mode_for_context(cfg->think_mode, cfg->ctx_size) == DS4_THINK_HIGH) {
         return;
     }
     fprintf(stderr,
             "ds4-eval: warning: --think-max needs --ctx >= %u; ctx=%d uses normal thinking instead\n",
-            ds4_think_max_min_context(),
+            ds4_think_effort_min_context(),
             cfg->ctx_size);
 }
 

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -828,7 +828,12 @@ static bool parse_reasoning_effort_name(const char *s, ds4_think_mode *out) {
         *out = DS4_THINK_LOW;
         return true;
     }
-    if (!strcmp(s, "none")) {
+    /* "off" is what UIs actually send for the disabled state (Open WebUI 0.11
+     * does, measured 2026-08-01), and rejecting it is worse than it looks: an
+     * unknown effort value fails the whole request body parse, so the caller
+     * gets a 400 "invalid JSON request" for well-formed JSON and no hint which
+     * field was at fault. */
+    if (!strcmp(s, "none") || !strcmp(s, "off")) {
         *out = DS4_THINK_NONE;
         return true;
     }
@@ -16068,6 +16073,8 @@ static void test_reasoning_effort_mapping(void) {
     TEST_ASSERT(parse_reasoning_effort_name("xhigh", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("max", &mode) && mode == DS4_THINK_MAX);
     TEST_ASSERT(parse_reasoning_effort_name("none", &mode) && mode == DS4_THINK_NONE);
+    /* UIs spell the disabled state "off"; Open WebUI sends exactly this. */
+    TEST_ASSERT(parse_reasoning_effort_name("off", &mode) && mode == DS4_THINK_NONE);
     TEST_ASSERT(!parse_reasoning_effort_name("banana", &mode));
 
     /* Each level injects exactly the reference encoder's string, and low

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -783,7 +783,7 @@ static void request_init(request *r, req_kind kind, int max_tokens) {
     r->temperature = server_default_temperature();
     r->top_p = DS4_DEFAULT_TOP_P;
     r->min_p = DS4_DEFAULT_MIN_P;
-    r->think_mode = DS4_THINK_HIGH;
+    r->think_mode = DS4_THINK_LOW;
 }
 
 static void request_free(request *r) {
@@ -805,23 +805,27 @@ static void request_free(request *r) {
 
 static ds4_think_mode think_mode_from_enabled(bool enabled, ds4_think_mode effort) {
     if (!enabled || effort == DS4_THINK_NONE) return DS4_THINK_NONE;
-    return effort == DS4_THINK_MAX ? DS4_THINK_MAX : DS4_THINK_HIGH;
+    return effort;
 }
 
 static bool parse_reasoning_effort_name(const char *s, ds4_think_mode *out) {
     if (!s) return false;
+    /* The three levels the 0731 checkpoint defines, plus the OpenAI-style
+     * aliases agent frameworks send.  Aliases map to the nearest level that
+     * exists rather than being rejected: "minimal"/"medium" have no upstream
+     * counterpart, so they round to the level below, and "xhigh" rounds to
+     * "high" rather than escalating to "max" -- rounding down never spends a
+     * caller's context on deliberation they did not ask for. */
     if (!strcmp(s, "max")) {
         *out = DS4_THINK_MAX;
         return true;
     }
-    if (!strcmp(s, "xhigh") || !strcmp(s, "high") ||
-        !strcmp(s, "medium") || !strcmp(s, "low") ||
-        !strcmp(s, "minimal"))
-    {
-        /* DS4 only exposes HIGH and MAX above zero, so "minimal" collapses to
-         * the smallest non-zero level (HIGH). Callers that need *no* reasoning
-         * must use "none" instead. */
+    if (!strcmp(s, "high") || !strcmp(s, "xhigh")) {
         *out = DS4_THINK_HIGH;
+        return true;
+    }
+    if (!strcmp(s, "low") || !strcmp(s, "medium") || !strcmp(s, "minimal")) {
+        *out = DS4_THINK_LOW;
         return true;
     }
     if (!strcmp(s, "none")) {
@@ -2331,7 +2335,7 @@ static char *render_chat_prompt_text(const chat_msgs *msgs, const char *tool_sch
 
     buf out = {0};
     buf_puts(&out, "<｜begin▁of▁sentence｜>");
-    if (think_mode == DS4_THINK_MAX) buf_puts(&out, ds4_think_max_prefix());
+    buf_puts(&out, ds4_think_effort_prefix(think_mode));
     buf_puts(&out, system.ptr ? system.ptr : "");
 
     bool pending_assistant = false;
@@ -2661,7 +2665,7 @@ static bool parse_chat_request(ds4_engine *e, server *s, const char *body, int d
     bool tool_choice_none = false;
     bool got_thinking = false;
     bool thinking_enabled = true;
-    ds4_think_mode reasoning_effort = DS4_THINK_HIGH;
+    ds4_think_mode reasoning_effort = DS4_THINK_LOW;
     chat_msgs msgs = {0};
     char *tool_schemas = NULL;
 
@@ -2839,7 +2843,7 @@ static bool parse_anthropic_request(ds4_engine *e, server *s, const char *body, 
     bool tool_choice_none = false;
     bool got_thinking = false;
     bool thinking_enabled = true;
-    ds4_think_mode reasoning_effort = DS4_THINK_HIGH;
+    ds4_think_mode reasoning_effort = DS4_THINK_LOW;
     chat_msgs msgs = {0};
     char *system = NULL;
     char *tool_schemas = NULL;
@@ -3729,7 +3733,7 @@ static bool parse_responses_request(ds4_engine *e, server *s, const char *body, 
     bool tool_choice_none = false;
     bool got_thinking = false;
     bool thinking_enabled = true;
-    ds4_think_mode reasoning_effort = DS4_THINK_HIGH;
+    ds4_think_mode reasoning_effort = DS4_THINK_LOW;
     chat_msgs msgs = {0};
     buf loaded_tool_schemas = {0};
     char *instructions = NULL;
@@ -4022,7 +4026,7 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
     char *prompt = NULL;
     bool got_thinking = false;
     bool thinking_enabled = true;
-    ds4_think_mode reasoning_effort = DS4_THINK_HIGH;
+    ds4_think_mode reasoning_effort = DS4_THINK_LOW;
 
     json_ws(&p);
     if (*p != '{') goto bad;
@@ -4147,7 +4151,7 @@ static bool parse_completion_request(ds4_engine *e, const char *body, int def_to
         think_mode_from_enabled(thinking_enabled, reasoning_effort), ctx_size);
     buf rendered = {0};
     buf_puts(&rendered, "<｜begin▁of▁sentence｜>");
-    if (r->think_mode == DS4_THINK_MAX) buf_puts(&rendered, ds4_think_max_prefix());
+    buf_puts(&rendered, ds4_think_effort_prefix(r->think_mode));
     buf_puts(&rendered, "You are a helpful assistant<｜User｜>");
     buf_puts(&rendered, prompt);
     buf_puts(&rendered, "<｜Assistant｜>");
@@ -9838,10 +9842,14 @@ static char *rendered_chat_system_region(const char *prompt_text) {
     const char *bos = "<｜begin▁of▁sentence｜>";
     const size_t bos_len = strlen(bos);
     if (!strncmp(p, bos, bos_len)) p += bos_len;
-    const char *max_prefix = ds4_think_max_prefix();
-    const size_t max_prefix_len = strlen(max_prefix);
-    if (max_prefix_len && !strncmp(p, max_prefix, max_prefix_len)) {
-        p += max_prefix_len;
+    /* Skip whichever effort prefix this prompt was rendered with, if any. */
+    const char *effort_prefixes[] = { ds4_think_high_prefix(), ds4_think_max_prefix() };
+    for (size_t i = 0; i < sizeof(effort_prefixes) / sizeof(effort_prefixes[0]); i++) {
+        const size_t plen = strlen(effort_prefixes[i]);
+        if (plen && !strncmp(p, effort_prefixes[i], plen)) {
+            p += plen;
+            break;
+        }
     }
     while (*p && isspace((unsigned char)*p)) p++;
 
@@ -13294,7 +13302,7 @@ static void handle_batch(server *s, int fd, const char *body) {
 
     const int ctx_size = s->serial_boot_ctx;   /* client thread: must not read
                                                   the swap-able serial session */
-    const ds4_think_mode tm = think ? ds4_think_mode_for_context(DS4_THINK_HIGH, ctx_size)
+    const ds4_think_mode tm = think ? ds4_think_mode_for_context(DS4_THINK_LOW, ctx_size)
                                     : DS4_THINK_NONE;
     ds4_tokens *toks = calloc((size_t)n, sizeof(*toks));
     ds4_batch_gen_result *res = calloc((size_t)n, sizeof(*res));
@@ -14960,7 +14968,7 @@ static void test_responses_input_function_call_namespace_round_trips_to_dsml(voi
     TEST_ASSERT(!strcmp(msgs.v[0].calls.v[0].name,
                         "mcp__perplexity__perplexity_search"));
 
-    char *prompt = render_chat_prompt_text(&msgs, schemas, &orders, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, schemas, &orders, DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(strstr(prompt,
         "<｜DSML｜invoke name=\"mcp__perplexity__perplexity_search\">") != NULL);
@@ -15155,7 +15163,7 @@ static void test_anthropic_live_stream_sends_incremental_blocks(void) {
     request_init(&r, REQ_CHAT, 128);
     r.api = API_ANTHROPIC;
     r.stream = true;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.has_tools = true;
     r.tool_orders = make_bash_order();
 
@@ -15349,7 +15357,7 @@ static void test_openai_tool_stream_sends_incremental_text(void) {
     request_init(&r, REQ_CHAT, 128);
     r.api = API_OPENAI;
     r.stream = true;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.has_tools = true;
     r.tool_orders = make_bash_order();
 
@@ -15592,7 +15600,7 @@ static void test_tools_batchable_at_any_temperature_and_thinking(void) {
     TEST_ASSERT(job_is_batchable(&r));
     r.temperature = 0.7f;
     TEST_ASSERT(job_is_batchable(&r));
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     TEST_ASSERT(job_is_batchable(&r));
     request_free(&r);
 
@@ -15653,7 +15661,7 @@ static void test_openai_chat_stream_splits_reasoning_without_tools(void) {
     request_init(&r, REQ_CHAT, 128);
     r.api = API_OPENAI;
     r.stream = true;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.has_tools = false;
 
     TEST_ASSERT(request_uses_structured_stream(&r));
@@ -16042,7 +16050,7 @@ static void test_streaming_holds_partial_utf8(void) {
 static void test_request_defaults_use_min_p_filtering(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
-    TEST_ASSERT(r.think_mode == DS4_THINK_HIGH);
+    TEST_ASSERT(r.think_mode == DS4_THINK_LOW);
     TEST_ASSERT(r.temperature == DS4_DEFAULT_TEMPERATURE);
     TEST_ASSERT(r.top_p == DS4_DEFAULT_TOP_P);
     TEST_ASSERT(r.top_k == 0);
@@ -16052,15 +16060,51 @@ static void test_request_defaults_use_min_p_filtering(void) {
 
 static void test_reasoning_effort_mapping(void) {
     ds4_think_mode mode = DS4_THINK_NONE;
-    TEST_ASSERT(parse_reasoning_effort_name("low", &mode) && mode == DS4_THINK_HIGH);
-    TEST_ASSERT(parse_reasoning_effort_name("medium", &mode) && mode == DS4_THINK_HIGH);
+    /* The three levels are distinct now; aliases round DOWN to the nearest. */
+    TEST_ASSERT(parse_reasoning_effort_name("low", &mode) && mode == DS4_THINK_LOW);
+    TEST_ASSERT(parse_reasoning_effort_name("minimal", &mode) && mode == DS4_THINK_LOW);
+    TEST_ASSERT(parse_reasoning_effort_name("medium", &mode) && mode == DS4_THINK_LOW);
     TEST_ASSERT(parse_reasoning_effort_name("high", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("xhigh", &mode) && mode == DS4_THINK_HIGH);
     TEST_ASSERT(parse_reasoning_effort_name("max", &mode) && mode == DS4_THINK_MAX);
+    TEST_ASSERT(parse_reasoning_effort_name("none", &mode) && mode == DS4_THINK_NONE);
     TEST_ASSERT(!parse_reasoning_effort_name("banana", &mode));
-    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX, 32768) == DS4_THINK_HIGH);
+
+    /* Each level injects exactly the reference encoder's string, and low
+     * injects nothing at all -- the property that keeps the default byte
+     * identical to the pre-change engine. */
+    TEST_ASSERT(ds4_think_effort_prefix(DS4_THINK_NONE)[0] == '\0');
+    TEST_ASSERT(ds4_think_effort_prefix(DS4_THINK_LOW)[0] == '\0');
+    TEST_ASSERT(!strcmp(ds4_think_effort_prefix(DS4_THINK_HIGH), ds4_think_high_prefix()));
+    TEST_ASSERT(!strcmp(ds4_think_effort_prefix(DS4_THINK_MAX), ds4_think_max_prefix()));
+    TEST_ASSERT(strcmp(ds4_think_high_prefix(), ds4_think_max_prefix()) != 0);
+    TEST_ASSERT(!strncmp(ds4_think_high_prefix(),
+                         "Reasoning Effort: Absolute maximum", 33));
+    TEST_ASSERT(!strncmp(ds4_think_max_prefix(),
+                         "Reasoning Effort: Beyond maximum", 32));
+
+    /* The context gate governs BOTH prefixed levels and falls back to low. */
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_HIGH, 32768) == DS4_THINK_LOW);
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX, 32768) == DS4_THINK_LOW);
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_LOW, 32768) == DS4_THINK_LOW);
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_NONE, 32768) == DS4_THINK_NONE);
+    TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_HIGH,
+                                           (int)ds4_think_effort_min_context()) == DS4_THINK_HIGH);
     TEST_ASSERT(ds4_think_mode_for_context(DS4_THINK_MAX,
-                                           (int)ds4_think_max_min_context()) == DS4_THINK_MAX);
+                                           (int)ds4_think_effort_min_context()) == DS4_THINK_MAX);
+
+    /* Names round-trip the wire vocabulary. */
+    TEST_ASSERT(!strcmp(ds4_think_mode_name(DS4_THINK_NONE), "none"));
+    TEST_ASSERT(!strcmp(ds4_think_mode_name(DS4_THINK_LOW), "low"));
+    TEST_ASSERT(!strcmp(ds4_think_mode_name(DS4_THINK_HIGH), "high"));
+    TEST_ASSERT(!strcmp(ds4_think_mode_name(DS4_THINK_MAX), "max"));
+
+    /* think_mode_from_enabled preserves the tier instead of flattening it. */
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_MAX) == DS4_THINK_MAX);
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_HIGH) == DS4_THINK_HIGH);
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_LOW) == DS4_THINK_LOW);
+    TEST_ASSERT(think_mode_from_enabled(false, DS4_THINK_MAX) == DS4_THINK_NONE);
+    TEST_ASSERT(think_mode_from_enabled(true, DS4_THINK_NONE) == DS4_THINK_NONE);
 }
 
 static void test_api_thinking_controls_parse(void) {
@@ -16072,13 +16116,13 @@ static void test_api_thinking_controls_parse(void) {
     TEST_ASSERT(parse_thinking_control_value(&thinking, &enabled));
     TEST_ASSERT(enabled);
 
-    ds4_think_mode mode = DS4_THINK_HIGH;
+    ds4_think_mode mode = DS4_THINK_LOW;
     const char *anth_effort = "{\"effort\":\"max\",\"other\":true}";
     TEST_ASSERT(parse_output_config_effort(&anth_effort, &mode));
     TEST_ASSERT(mode == DS4_THINK_MAX);
 
     const char *openai_effort = "\"xhigh\"";
-    mode = DS4_THINK_HIGH;
+    mode = DS4_THINK_LOW;
     TEST_ASSERT(parse_reasoning_effort_value(&openai_effort, &mode));
     TEST_ASSERT(mode == DS4_THINK_HIGH);
 }
@@ -16094,14 +16138,43 @@ static void test_render_think_max_prompt_prefix(void) {
     user.content = xstrdup("Hello");
     chat_msgs_push(&msgs, user);
 
-    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_MAX);
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(!strncmp(prompt, "<｜begin▁of▁sentence｜>", strlen("<｜begin▁of▁sentence｜>")));
-    TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) != NULL);
+    TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) != NULL);
     TEST_ASSERT(strstr(prompt, "You are terse.<｜User｜>Hello<｜Assistant｜><think>") != NULL);
     TEST_ASSERT(strstr(prompt, "</think>") == NULL);
 
     free(prompt);
+    chat_msgs_free(&msgs);
+}
+
+static void test_render_think_effort_prefix_tiers(void) {
+    chat_msgs msgs = {0};
+    chat_msg user = {0};
+    user.role = xstrdup("user");
+    user.content = xstrdup("Hello");
+    chat_msgs_push(&msgs, user);
+
+    /* max injects the "Beyond maximum" string, NOT high's. */
+    char *pmax = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_MAX);
+    TEST_ASSERT(pmax != NULL);
+    TEST_ASSERT(strstr(pmax, ds4_think_max_prefix()) != NULL);
+    TEST_ASSERT(strstr(pmax, ds4_think_high_prefix()) == NULL);
+    TEST_ASSERT(strstr(pmax, "<｜User｜>Hello<｜Assistant｜><think>") != NULL);
+
+    /* low still thinks, but injects nothing: this is the byte-compatibility
+     * property against the pre-change engine's ordinary thinking mode. */
+    char *plow = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
+    TEST_ASSERT(plow != NULL);
+    TEST_ASSERT(strstr(plow, ds4_think_high_prefix()) == NULL);
+    TEST_ASSERT(strstr(plow, ds4_think_max_prefix()) == NULL);
+    TEST_ASSERT(strstr(plow, "<｜User｜>Hello<｜Assistant｜><think>") != NULL);
+    TEST_ASSERT(!strncmp(plow, "<｜begin▁of▁sentence｜><｜User｜>",
+                         strlen("<｜begin▁of▁sentence｜><｜User｜>")));
+
+    free(pmax);
+    free(plow);
     chat_msgs_free(&msgs);
 }
 
@@ -16114,7 +16187,7 @@ static void test_render_non_thinking_prompt_closes_think(void) {
 
     char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_NONE);
     TEST_ASSERT(prompt != NULL);
-    TEST_ASSERT(strstr(prompt, ds4_think_max_prefix()) == NULL);
+    TEST_ASSERT(strstr(prompt, ds4_think_high_prefix()) == NULL);
     TEST_ASSERT(strstr(prompt, "<｜User｜>Hello<｜Assistant｜></think>") != NULL);
     free(prompt);
     chat_msgs_free(&msgs);
@@ -16136,7 +16209,7 @@ static void test_render_drops_old_reasoning_without_tools(void) {
     user2.content = xstrdup("second");
     chat_msgs_push(&msgs, user2);
 
-    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(strstr(prompt, "old hidden reasoning") == NULL);
     TEST_ASSERT(strstr(prompt, "<｜Assistant｜></think>first answer") != NULL);
@@ -16166,13 +16239,13 @@ static void test_render_preserves_reasoning_with_tools(void) {
     tool.content = xstrdup("/tmp");
     chat_msgs_push(&msgs, tool);
 
-    char *prompt = render_chat_prompt_text(&msgs, "{}", NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, "{}", NULL, DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(strstr(prompt, "<think>tool reasoning</think>") != NULL);
     TEST_ASSERT(strstr(prompt, "<tool_result>/tmp</tool_result>") != NULL);
     free(prompt);
 
-    prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(strstr(prompt, "<think>tool reasoning</think>") != NULL);
     TEST_ASSERT(strstr(prompt, "<tool_result>/tmp</tool_result>") != NULL);
@@ -16197,7 +16270,7 @@ static void test_render_chat_prompt_text_renders_tools_before_system(void) {
     chat_msgs_push(&msgs, user);
 
     char *prompt = render_chat_prompt_text(&msgs, "TOOL_SCHEMA_MARKER", NULL,
-                                           DS4_THINK_HIGH);
+                                           DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     const char *tools  = strstr(prompt, "## Tools");
     const char *client = strstr(prompt, "CLIENT_SYSTEM_MARKER");
@@ -16289,7 +16362,7 @@ static void test_parse_short_dsml_and_canonical_suffix(void) {
 
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.tool_orders = make_bash_order();
     char *suffix = build_tool_checkpoint_suffix(&r, content, reasoning, &calls);
     const char *command = strstr(suffix, "name=\"command\"");
@@ -16582,7 +16655,7 @@ static void test_tool_parse_failure_returns_recoverable_finish(void) {
 
 static void test_invalid_dsml_tool_error_suffix_includes_system_prompt(void) {
     request r = {0};
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.prompt_text = xstrdup(
         "<｜begin▁of▁sentence｜>"
         "## Tools\nschema\n\nSystem rule\n\n"
@@ -16663,7 +16736,7 @@ static void test_tool_checkpoint_suffix_is_future_prompt_canonical(void) {
     user.content = xstrdup("inspect");
     chat_msgs_push(&prefix_msgs, user);
     char *prompt_text = render_chat_prompt_text(&prefix_msgs, tool_schemas,
-                                                &orders, DS4_THINK_HIGH);
+                                                &orders, DS4_THINK_LOW);
 
     const char *generated =
         "need a tool</think>\n\n"
@@ -16683,7 +16756,7 @@ static void test_tool_checkpoint_suffix_is_future_prompt_canonical(void) {
 
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.tool_orders = orders;
     memset(&orders, 0, sizeof(orders));
     char *suffix = build_tool_checkpoint_suffix(&r, content, reasoning, &calls);
@@ -16707,7 +16780,7 @@ static void test_tool_checkpoint_suffix_is_future_prompt_canonical(void) {
     memset(&calls, 0, sizeof(calls));
     chat_msgs_push(&history_msgs, assistant);
     char *future_prompt = render_chat_prompt_text(&history_msgs, tool_schemas,
-                                                  &r.tool_orders, DS4_THINK_HIGH);
+                                                  &r.tool_orders, DS4_THINK_LOW);
 
     TEST_ASSERT(!strcmp(canonical.ptr, future_prompt));
 
@@ -16739,7 +16812,7 @@ static void test_tool_checkpoint_minifies_json_parameters(void) {
     user.content = xstrdup("edit");
     chat_msgs_push(&prefix_msgs, user);
     char *prompt_text = render_chat_prompt_text(&prefix_msgs, tool_schemas,
-                                                &orders, DS4_THINK_HIGH);
+                                                &orders, DS4_THINK_LOW);
 
     const char *generated =
         "need edit</think>\n\n"
@@ -16760,7 +16833,7 @@ static void test_tool_checkpoint_minifies_json_parameters(void) {
 
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.tool_orders = orders;
     memset(&orders, 0, sizeof(orders));
     char *suffix = build_tool_checkpoint_suffix(&r, content, reasoning, &calls);
@@ -16781,7 +16854,7 @@ static void test_tool_checkpoint_minifies_json_parameters(void) {
     memset(&calls, 0, sizeof(calls));
     chat_msgs_push(&history_msgs, assistant);
     char *future_prompt = render_chat_prompt_text(&history_msgs, tool_schemas,
-                                                  &r.tool_orders, DS4_THINK_HIGH);
+                                                  &r.tool_orders, DS4_THINK_LOW);
 
     TEST_ASSERT(!strcmp(canonical.ptr, future_prompt));
 
@@ -16842,7 +16915,7 @@ static void test_tool_memory_replays_sampled_dsml(void) {
     TEST_ASSERT(stats.disk == 0);
     TEST_ASSERT(stats.canonical == 0);
     TEST_ASSERT(stats.missing_ids == 0);
-    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     const char *command = strstr(prompt, "name=\"command\"");
     const char *timeout = strstr(prompt, "name=\"timeout\"");
     const char *description = strstr(prompt, "name=\"description\"");
@@ -16902,7 +16975,7 @@ static void test_anthropic_tool_memory_replays_sampled_dsml(void) {
     TEST_ASSERT(stats.mem == 1);
     TEST_ASSERT(stats.canonical == 0);
 
-    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     const char *command = strstr(prompt, "name=\"command\"");
     const char *description = strstr(prompt, "name=\"description\"");
     TEST_ASSERT(command != NULL);
@@ -16919,7 +16992,7 @@ static void test_anthropic_live_tail_renders_tool_results_only(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
     r.api = API_ANTHROPIC;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
 
     chat_msgs msgs = {0};
     chat_msg assistant = {0};
@@ -17103,7 +17176,7 @@ static void test_responses_live_tail_renders_tool_outputs_only(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
     r.api = API_RESPONSES;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
 
     chat_msgs msgs = {0};
     chat_msg assistant = {0};
@@ -17148,7 +17221,7 @@ static void test_responses_tool_output_id_validation(void) {
     chat_msgs_push(&msgs, tool);
 
     char err[160] = {0};
-    TEST_ASSERT(!responses_validate_tool_outputs(&s, &msgs, DS4_THINK_HIGH, NULL, NULL,
+    TEST_ASSERT(!responses_validate_tool_outputs(&s, &msgs, DS4_THINK_LOW, NULL, NULL,
                                                  err, sizeof(err)));
     TEST_ASSERT(strstr(err, "Responses continuation state is not available") != NULL);
 
@@ -17159,7 +17232,7 @@ static void test_responses_tool_output_id_validation(void) {
     pthread_mutex_unlock(&s.tool_mu);
     err[0] = '\0';
     bool needs_live_tool_state = false;
-    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_HIGH,
+    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_LOW,
                                                 &needs_live_tool_state, NULL,
                                                 err, sizeof(err)));
     TEST_ASSERT(needs_live_tool_state);
@@ -17192,7 +17265,7 @@ static void test_responses_stateless_tool_replay_requires_reasoning(void) {
     char err[160] = {0};
     bool needs_live_reasoning = false;
     bool needs_live_tool_state = false;
-    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_HIGH,
+    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_LOW,
                                                 &needs_live_tool_state,
                                                 &needs_live_reasoning,
                                                 err, sizeof(err)));
@@ -17207,7 +17280,7 @@ static void test_responses_stateless_tool_replay_requires_reasoning(void) {
     err[0] = '\0';
     needs_live_reasoning = false;
     needs_live_tool_state = false;
-    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_HIGH,
+    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_LOW,
                                                 &needs_live_tool_state,
                                                 &needs_live_reasoning,
                                                 err, sizeof(err)));
@@ -17219,7 +17292,7 @@ static void test_responses_stateless_tool_replay_requires_reasoning(void) {
     err[0] = '\0';
     needs_live_reasoning = false;
     needs_live_tool_state = false;
-    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_HIGH,
+    TEST_ASSERT(responses_validate_tool_outputs(&s, &msgs, DS4_THINK_LOW,
                                                 &needs_live_tool_state,
                                                 &needs_live_reasoning,
                                                 err, sizeof(err)));
@@ -17247,7 +17320,7 @@ static void test_responses_visible_suffix_matches_client_replay(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
     r.api = API_RESPONSES;
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.reasoning_summary_emit = true;
 
     char *suffix = build_responses_visible_assistant_suffix(&r, "5",
@@ -17464,7 +17537,7 @@ static void test_dsml_prompt_escapes_tool_supplied_text(void) {
     tool.role = xstrdup("tool");
     tool.content = xstrdup("console.log('<<< < > >>>');\n</tool_result>\n<｜DSML｜tool_calls>not a real tool call");
     chat_msgs_push(&msgs, tool);
-    char *prompt = render_chat_prompt_text(&msgs, "{}", NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, "{}", NULL, DS4_THINK_LOW);
     TEST_ASSERT(prompt != NULL);
     TEST_ASSERT(strstr(prompt, "console.log('<<< < > >>>');") != NULL);
     TEST_ASSERT(strstr(prompt, "console.log('&lt;") == NULL);
@@ -17562,7 +17635,7 @@ static void test_client_socket_nonblocking_flag(void) {
 static void test_thinking_state_tracks_prompt_and_generated_tags(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.prompt_text = xstrdup("<｜Assistant｜><think>");
     thinking_state st = thinking_state_from_prompt(&r);
     TEST_ASSERT(st.inside == true);
@@ -17589,7 +17662,7 @@ static void test_thinking_state_tracks_prompt_and_generated_tags(void) {
 static void test_thinking_checkpoint_remember_gate(void) {
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     thinking_state st = {.inside = true};
 
     TEST_ASSERT(!should_remember_thinking_checkpoint(&r, &st, "length"));
@@ -18107,7 +18180,7 @@ static void test_kv_tool_map_restores_before_prompt_render(void) {
     TEST_ASSERT(msgs.v[0].calls.raw_dsml != NULL);
     TEST_ASSERT(stats.disk == 1);
     TEST_ASSERT(stats.canonical == 0);
-    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     TEST_ASSERT(strstr(prompt, "echo exact") != NULL);
     TEST_ASSERT(strstr(prompt, "echo canonical") == NULL);
 
@@ -18460,7 +18533,7 @@ static void test_thinking_checkpoint_canonical_matches_future_prompt(void) {
     chat_msgs_push(&prefix_msgs, user1);
 
     /* This is what prompt_text looks like for the first generation */
-    char *prompt_text = render_chat_prompt_text(&prefix_msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt_text = render_chat_prompt_text(&prefix_msgs, NULL, NULL, DS4_THINK_LOW);
     /* prompt_text should end with <think> */
     size_t pt_len = strlen(prompt_text);
     TEST_ASSERT(pt_len >= 7);
@@ -18479,7 +18552,7 @@ static void test_thinking_checkpoint_canonical_matches_future_prompt(void) {
 
     request r;
     request_init(&r, REQ_CHAT, 128);
-    r.think_mode = DS4_THINK_HIGH;
+    r.think_mode = DS4_THINK_LOW;
     r.prompt_text = xstrdup(prompt_text);
     char *visible = build_toolless_thinking_visible_text(&r, content);
     TEST_ASSERT(visible != NULL);
@@ -18505,7 +18578,7 @@ static void test_thinking_checkpoint_canonical_matches_future_prompt(void) {
     h_user2.content = xstrdup("Thanks!");
     chat_msgs_push(&history_msgs, h_user2);
 
-    char *future_prompt = render_chat_prompt_text(&history_msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *future_prompt = render_chat_prompt_text(&history_msgs, NULL, NULL, DS4_THINK_LOW);
 
     /* The future prompt should START with our canonical text */
     size_t clen = canonical.len;
@@ -18539,7 +18612,7 @@ static void test_thinking_canonical_empty_content(void) {
     user.content = xstrdup("Think about life");
     chat_msgs_push(&msgs, user);
 
-    char *prompt_text = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt_text = render_chat_prompt_text(&msgs, NULL, NULL, DS4_THINK_LOW);
     size_t pt_len = strlen(prompt_text);
 
     /* Build canonical with empty content */
@@ -18565,7 +18638,7 @@ static void test_thinking_canonical_empty_content(void) {
     h_u2.content = xstrdup("Continue");
     chat_msgs_push(&history, h_u2);
 
-    char *future = render_chat_prompt_text(&history, NULL, NULL, DS4_THINK_HIGH);
+    char *future = render_chat_prompt_text(&history, NULL, NULL, DS4_THINK_LOW);
     TEST_ASSERT(strlen(future) > canonical.len);
     TEST_ASSERT(!memcmp(future, canonical.ptr, canonical.len));
     /* reasoning dropped */
@@ -18599,7 +18672,7 @@ static void test_thinking_canonical_multi_turn(void) {
     chat_msgs_push(&turn2_prefix, u2);
 
     /* prompt_text for the 2nd generation (includes 1st assistant turn) */
-    char *prompt_text = render_chat_prompt_text(&turn2_prefix, NULL, NULL, DS4_THINK_HIGH);
+    char *prompt_text = render_chat_prompt_text(&turn2_prefix, NULL, NULL, DS4_THINK_LOW);
     size_t pt_len = strlen(prompt_text);
     TEST_ASSERT(!memcmp(prompt_text + pt_len - 7, "<think>", 7));
 
@@ -18632,7 +18705,7 @@ static void test_thinking_canonical_multi_turn(void) {
     chat_msg fu3 = {0}; fu3.role = xstrdup("user"); fu3.content = xstrdup("Great");
     chat_msgs_push(&future_msgs, fu3);
 
-    char *future = render_chat_prompt_text(&future_msgs, NULL, NULL, DS4_THINK_HIGH);
+    char *future = render_chat_prompt_text(&future_msgs, NULL, NULL, DS4_THINK_LOW);
     /* Both reasonings dropped */
     TEST_ASSERT(strstr(future, "first reasoning") == NULL);
     TEST_ASSERT(strstr(future, "second reasoning") == NULL);
@@ -18660,7 +18733,7 @@ static void test_thinking_canonical_with_tools_preserves_reasoning(void) {
     u.content = xstrdup("run ls");
     chat_msgs_push(&msgs, u);
 
-    char *prompt_text = render_chat_prompt_text(&msgs, tool_schemas, NULL, DS4_THINK_HIGH);
+    char *prompt_text = render_chat_prompt_text(&msgs, tool_schemas, NULL, DS4_THINK_LOW);
     size_t pt_len = strlen(prompt_text);
     TEST_ASSERT(!memcmp(prompt_text + pt_len - 7, "<think>", 7));
 
@@ -18675,7 +18748,7 @@ static void test_thinking_canonical_with_tools_preserves_reasoning(void) {
     chat_msg hu2 = {0}; hu2.role = xstrdup("user"); hu2.content = xstrdup("thanks");
     chat_msgs_push(&history, hu2);
 
-    char *future = render_chat_prompt_text(&history, tool_schemas, NULL, DS4_THINK_HIGH);
+    char *future = render_chat_prompt_text(&history, tool_schemas, NULL, DS4_THINK_LOW);
     /* Reasoning IS preserved when tools present */
     TEST_ASSERT(strstr(future, "I should run bash") != NULL);
     TEST_ASSERT(strstr(future, "<think>I should run bash</think>") != NULL);
@@ -18713,6 +18786,7 @@ static void ds4_server_unit_tests_run(void) {
     test_reasoning_effort_mapping();
     test_api_thinking_controls_parse();
     test_render_think_max_prompt_prefix();
+    test_render_think_effort_prefix_tiers();
     test_render_non_thinking_prompt_closes_think();
     test_render_drops_old_reasoning_without_tools();
     test_render_preserves_reasoning_with_tools();


### PR DESCRIPTION
### What this fixes

`DeepSeek-V4-Flash-0731` [documents three `reasoning_effort` levels — `low`, `high`, `max`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731#chat-template) — and ships the reference encoder that defines them (`encoding/encoding_dsv4.py`, `REASONING_EFFORT_PROMPTS`). The engine currently exposes two non-zero levels and labels them one tier too low:

| requested | engine emits today | upstream's name for that |
|---|---|---|
| `minimal` / `low` / `medium` / `high` / `xhigh` | no prefix | `low` |
| `max` | the "Absolute maximum…" string | **`high`** |
| — | *(nothing emits it)* | **`max`** — unreachable |

So a caller selecting `max` silently receives `high`, and upstream's `max` has no representation at all. The five spellings that collapse are also indistinguishable on the wire: at a fixed seed they return byte-identical `reasoning_content`.

Separately, `reasoning_effort: "off"` is rejected with `400 "invalid JSON request"` for well-formed JSON, because an unrecognised effort value fails the whole body parse and the error names no field. That makes thinking-off unreachable from clients that spell it that way — Open WebUI 0.11 does.

### Why

Fidelity to the checkpoint's documented interface. The model card and the reference encoder define three levels; the server should implement what the model documents. This PR does not argue that the levels produce measurably different behaviour — see the caveat below, where the honest answer is that we could not establish it. The case for the change is that the interface should match its source, and that a caller asking for `max` should not silently receive `high`.

### Mechanism, and why prefixes are the whole of it

Not an approximation of a control-token scheme — there is no control-token scheme. The 0731 GGUF's embedded `tokenizer.chat_template` carries **no** `reasoning_effort` at all (one binary `thinking` boolean), and the checkpoint has no per-level token. `REASONING_EFFORT_PROMPTS` is therefore the definition, and both strings here are verbatim from it, injected at the very start of the conversation ahead of the system message — which is where `render_message` puts them (`index == 0 and thinking_mode == "thinking"`).

**Independently corroborated by the vLLM side.** The community vLLM recipe for this checkpoint (NVIDIA developer forum thread 372268, post 531) patches the two files DeepSeek ships and arrives at exactly this mechanism: the same `REASONING_EFFORT_PROMPTS` dict with `"low": ""`, and the same gate, verbatim:

```python
assert reasoning_effort is None or reasoning_effort in REASONING_EFFORT_PROMPTS
if index == 0 and thinking_mode == "thinking" and reasoning_effort in ("high", "max"):
    prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
```

Two independent implementations on two unrelated engines agreeing on injection point, gate condition and the empty-string default is stronger evidence than either could offer alone. Their stated expectation — "expect `prompt_tokens` to climb monotonically: `low` < `high` < `max`" — is exactly what the table below measures, with the deltas they do not report.

### Two deliberate divergences from that vLLM patch

Flagging both, since the vLLM recipe is the closest thing to a second reference implementation and a reviewer may reasonably prefer its choice:

- **`xhigh`**: that patch maps it **up** to `max` (`elif reasoning_effort == "xhigh": reasoning_effort = "max"`); this branch rounds it **down** to `high`. The reasoning here is that rounding up spends a caller's context and latency on deliberation they did not ask for, and `xhigh` is an OpenAI spelling with no DeepSeek counterpart, so neither mapping is authoritative. Easy to flip if you prefer theirs.
- **Unknown values**: that patch degrades anything outside `low`/`high`/`max` to `None`, i.e. the cheapest level; this branch keeps a fixed accept table and rejects the rest. Theirs is the more robust design and would have prevented the Open WebUI `"off"` 400 outright, rather than needing the specific alias the second commit adds. Worth considering as a follow-up: a permissive fallback makes the whole class of bug disappear instead of one instance of it.

### What changes

- `DS4_THINK_LOW` is added, so the enum reads `NONE < LOW < HIGH < MAX` and each level injects what its name claims. `low` is the empty string, matching the reference encoder's `DEFAULT_REASONING_EFFORT`.
- The two renames are mechanical and carry no behaviour: what the engine called `HIGH` was already upstream's `low`, and what it called `MAX` was already upstream's `high`.
- Aliases with no upstream counterpart round **down** rather than being rejected — `minimal`/`medium` to `low`, `xhigh` to `high` — so no caller spends context on deliberation it did not ask for.
- The context gate now governs both prefixed levels rather than `max` alone, falling back to `low`, since DeepSeek recommends the 384K output budget for `high` and `max` equally. `DS4_THINK_MAX_MIN_CONTEXT` is renamed to `DS4_THINK_EFFORT_MIN_CONTEXT` because a name saying "max" would now mislead.
- `"off"` is accepted as a spelling of `none`.

### What does not change

Requests that omit `reasoning_effort` still resolve to `LOW`, which is prefix-free, so **the default rendering is byte-identical to the previous engine**. Verified live rather than assumed: an omitted value and an explicit `low` return the same `reasoning_content` by sha256, on both the patched and stock binaries.

### Tests

Server unit tests (`./ds4_test --server`) cover the parse table including the alias rounding and `off`, the per-level prefix identity, the prefix-free property of `low`, the context gate on both prefixed tiers, the name round-trip, and tier-preserving resolution in `think_mode_from_enabled`. Two render tests assert that `max` injects its own string and not `high`'s, and that `low` injects neither while still opening `<think>`.

Live verification on a DGX Spark GB10 serving the 0731 checkpoint at ctx 524288, at a fixed seed:

| `reasoning_effort` | prompt tokens added | distinct reasoning? |
|---|---|---|
| omitted / `low` / `minimal` / `medium` | +0 | baseline |
| `high` / `xhigh` | **+79** | yes |
| `max` | **+92** | yes |
| `off` / `none` | +0 | thinking off, HTTP 200 |

Before this change, five spellings returned one byte-identical text and `max` returned upstream's `high` string. After, `low`/`high`/`max` return three distinct texts and the token deltas are exact. Confirmed through three independent clients (direct HTTP, the `pi` coding agent, Open WebUI 0.11), which is what rules out client-side rewriting.

**Re-verified unchanged after the v0.5.2 rebase** (2026-08-02, same seed, all nine spellings, all returning the correct answer). The `+0 / +79 / +92` signature is stable across the two base tags, which makes it a cheap regression check for future rebases.

### Caveat on behavioural evidence — please read before citing this PR

**We did not establish that the model deliberates measurably more at higher levels, and this PR should not be read as claiming so.** Five seeds per level on a **single** arithmetic word problem gave overlapping completion-token ranges for `low` (575–1286), `high` (462–1687) and `max` (379–1527); `high`'s median fell *below* `low`'s, and individual seeds produced both orderings. Only thinking-off separated cleanly.

Two reasons to treat that as inconclusive rather than negative:

1. **The task was too easy to discriminate.** Correctness was 5/5 at every level, so the sample carries no information about quality — only about output volume.
2. **One prompt, and not one that stresses reasoning.** The prefixes instruct the model to decompose to root cause, stress-test against edge cases, and verify from multiple angles. A problem solvable in two arithmetic steps gives those instructions nothing to bite on. A prompt set with a nonzero failure rate at `low`, scored on accuracy rather than tokens, is the experiment that would actually test the levels; we have not run it.

Thinking also forces temperature 1.0, so run-to-run variance is large and single samples are not evidence in either direction.

### Operational note for reviewers

Both prefixes are injected at position 0, so **changing effort level invalidates the entire prefix cache** and costs a full re-prefill. Measured: `pos_base=0` and ~16 s on a 15.8k-token prompt, against 1.9 s when `low` reuses the cache (`pos_base=15744`, 90 tokens re-prefilled). Worth knowing for anyone wiring effort into a per-turn agent control; it belongs to a session, not a turn.

### Environment

DGX Spark, GB10 / SM121, `make cuda CUDA_ARCH=sm_121`, `DeepSeek-V4-Flash-0731` IQ2_XXS/Q2_K + the matching 0731 DSpark drafter, ctx 524288, continuous batching (`DS4_SERVER_COALESCE_MAX=2`). Based on `v0.5.2`.

**Rebased from `v0.5.1` to `v0.5.2` on 2026-08-02**, which is why this branch was force-pushed and why it no longer shows as conflicting. Exactly one conflict, in `handle_batch`: v0.5.2 replaces `ds4_session_ctx(s->session)` with `s->serial_boot_ctx` on the same line this branch renames `DS4_THINK_HIGH` to `DS4_THINK_LOW`. Both edits are wanted and the resolution takes both — the serial-session read and the enum rename are independent changes that happen to share a line. The patch is otherwise content-identical to the `v0.5.1`-based version (verified by diffing the `+`/`-` lines of both patches), and `v0.5.2` introduces no new references to the think enum or the effort parser. The live verification table above was re-measured on the rebased build, not carried over.
