### PR TITLE
fix(cuda): trust MemAvailable for GB10 graph-fit gate (drop pinned-file subtraction)

### DIFF
--- a/ds4_cuda.cu
+++ b/ds4_cuda.cu
@@ -3064,14 +3064,25 @@ extern "C" int ds4_gpu_mem_info(uint64_t *free_bytes, uint64_t *total_bytes) {
             while (fgets(line, sizeof line, f)) {
                 unsigned long long kb = 0;
                 if (sscanf(line, "MemAvailable: %llu kB", &kb) == 1) {
-                    /* MemAvailable still counts GPU-pinned page-cache pages as
-                     * reclaimable; they cannot actually be claimed, and budgets
-                     * that spend them evict the model's residency (NVMe thrash
-                     * mid-decode).  Subtract the registered file-backed weight
-                     * mappings; anon (DS4_MODEL_ANON_HUGE) copies are already
-                     * excluded by the kernel. */
+                    /* MemAvailable is the kernel's own "allocatable before OOM"
+                     * estimate and, on GB10's HMM path, is accurate as-is:
+                     * cudaHostRegisterMapped does NOT mlock the model mapping
+                     * (measured Unevictable/Mlocked stay ~26 MiB while
+                     * g_pinned_file_bytes is ~6.5 GiB), so those file pages
+                     * remain genuinely reclaimable and MemAvailable already
+                     * counts them.
+                     *
+                     * A former `avail -= g_pinned_file_bytes` correction here
+                     * assumed discrete-GPU-style pinning (pages counted
+                     * reclaimable but actually unreclaimable).  That assumption
+                     * is false on this box: it double-penalized by the entire
+                     * registered model, drove free_out below the session-graph
+                     * need, and 503'd every serial request even though the
+                     * alloc fits -- the weights are served from the anon
+                     * DS4_MODEL_ANON_HUGE artifacts, so reclaiming the fallback
+                     * mapping's page cache does not thrash decode.  Trust
+                     * MemAvailable; the caller's own headroom is the margin. */
                     uint64_t avail = kb * 1024ull;
-                    avail = avail > g_pinned_file_bytes ? avail - g_pinned_file_bytes : 0;
                     if (avail > free_out) free_out = avail;
                     break;
                 }


### PR DESCRIPTION
## Summary
On integrated GB10 (DGX Spark), `ds4-server` boots fine but returns `503 serial right-size: no graph fits` for **every** request — even a few tokens — at any `-c`. Root cause is a bad free-memory estimate in `ds4_gpu_mem_info`; this drops the incorrect correction.

## Symptom
```
serial right-size: no graph fits (prompt=344 need_min=1368 boot -c 32768); refusing 503
```
The refusal happens at a ctx-independent floor, so the serial right-size search never finds a size that fits and nothing is served. `DS4_SESSION_GRAPH_FIT=0` works around it.

## Root cause
`ds4_gpu_mem_info` computed `free = max(MemFree, MemAvailable − g_pinned_file_bytes)`. The subtraction assumes `cudaHostRegister`'d model pages are counted reclaimable in `MemAvailable` but can't actually be reclaimed (discrete-GPU pinning). On GB10's HMM path that is false. Measured on-box at refusal:
```
MemFree=1889  MemAvailable=8893  pinned_file=6648  -> free_out=2245 MiB
fit-check ctx=32768: need=5606 + headroom=1024 = 6630  vs free=2245  -> REFUSE
```
`/proc/meminfo` shows `Unevictable`/`Mlocked` ≈ 26 MiB (not 6.6 GiB): `cudaHostRegisterMapped` does **not** mlock the mapping, so those pages stay reclaimable and `MemAvailable` (8893) already accounts for them. `MemAvailable` alone clears the need — matching the fact that the alloc really does fit and serve.

## Fix
Trust `MemAvailable`; drop the `−= g_pinned_file_bytes` correction (still `max`'d with `cudaMemGetInfo` free). Safe because weights are served from the anon `DS4_MODEL_ANON_HUGE` artifacts, so reclaiming the fallback mapping's page cache doesn't thrash decode. Integrated-only (`cudaDevAttrIntegrated`-gated); no change on discrete GPUs.

## Testing
GB10 / DeepSeek-V4-Flash IQ2XXS, `-c 32768`: before, all requests 503; after, 344-token and 27k-token tool prompts prefill (~880 t/s) and decode (~18 t/s) cleanly, tool calls included. Instrumented `free_out` rises 2245 → 8893 MiB and the gate flips `REFUSE → FIT`.
