### PR TITLE
Report proper metrics for llama-swap

### DIFF
--- a/ds4.c
+++ b/ds4.c
@@ -40235,14 +40235,18 @@ static bool ds4_mtp_exact_policy_use_seq(ds4_session *s) {
     return use_seq;
 }
 
+static void ds4_spec_stats_apply(ds4_spec_stats *st, int drafted,
+                                 int accepted_drafts) {
+    if (!st) return;
+    st->drafted = drafted;
+    st->accepted = accepted_drafts > 0 ? accepted_drafts : 0;
+}
+
 static void ds4_mtp_accept_gate_record(ds4_session *s,
                                        int accepted_drafts,
                                        int proposed_drafts,
                                        ds4_spec_stats *stats) {
-    if (stats) {
-        stats->drafted = proposed_drafts;
-        stats->accepted = accepted_drafts;
-    }
+    ds4_spec_stats_apply(stats, proposed_drafts, accepted_drafts);
     if (!s || proposed_drafts <= 0) return;
     if (accepted_drafts < 0) accepted_drafts = 0;
     if (accepted_drafts > proposed_drafts) accepted_drafts = proposed_drafts;
@@ -40483,7 +40487,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
     if (preserve_target_frontier && draft_cap > 1) {
         have_draft_frontier = spec_frontier_snapshot(&draft_frontier, s);
         if (!have_draft_frontier) {
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return n_accept;
         }
     }
@@ -40512,7 +40516,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                 s->graph.mtp_n_raw = mtp_n_raw_after_draft;
                 spec_frontier_free(&draft_frontier);
             }
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return n_accept;
         }
         if (mtp_fast_top2) mtp_last_top2 = mtp_top2;
@@ -40528,7 +40532,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             spec_frontier_free(&draft_frontier);
             snprintf(err, errlen, "MTP draft frontier restore failed");
             s->checkpoint_valid = false;
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return -1;
         }
         s->graph.mtp_n_raw = mtp_n_raw_after_draft;
@@ -40565,7 +40569,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                 free(row_logits);
                 snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
                 s->checkpoint_valid = false;
-                if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+                ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
                 return -1;
             }
             memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
@@ -40653,7 +40657,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         if (!ok) {
             snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return -1;
         }
         s->checkpoint_valid = true;
@@ -41430,7 +41434,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             free(shadow_exact_logits0);
             free(shadow_exact_logits1);
             free(row_tops);
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return -1;
         }
         spec_frontier_free(&frontier);
@@ -41479,7 +41483,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         if (!_ver_raw_ok) {
             snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return -1;
         }
         token_vec_push(&s->checkpoint, drafts[i]);
@@ -41496,7 +41500,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         {
             snprintf(err, errlen, "%s logits readback failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
-            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            ds4_spec_stats_apply(stats, draft_n, n_accept - 1);
             return -1;
         }
         logits_on_host = true;

--- a/ds4.c
+++ b/ds4.c
@@ -40237,7 +40237,12 @@ static bool ds4_mtp_exact_policy_use_seq(ds4_session *s) {
 
 static void ds4_mtp_accept_gate_record(ds4_session *s,
                                        int accepted_drafts,
-                                       int proposed_drafts) {
+                                       int proposed_drafts,
+                                       ds4_spec_stats *stats) {
+    if (stats) {
+        stats->drafted = proposed_drafts;
+        stats->accepted = accepted_drafts;
+    }
     if (!s || proposed_drafts <= 0) return;
     if (accepted_drafts < 0) accepted_drafts = 0;
     if (accepted_drafts > proposed_drafts) accepted_drafts = proposed_drafts;
@@ -40273,7 +40278,12 @@ static void ds4_mtp_accept_gate_record(ds4_session *s,
 int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                         int max_tokens, int eos_token,
                                         int *accepted, int accepted_cap,
+                                        ds4_spec_stats *stats,
                                         char *err, size_t errlen) {
+    if (stats) {
+        stats->drafted = 0;
+        stats->accepted = 0;
+    }
     if (!s || max_tokens <= 0 || accepted_cap <= 0) return 0;
     if (s->distributed) {
         if (!accepted) return 0;
@@ -40451,7 +40461,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     (target_done - cycle_t0) * 1000.0,
                     (now_sec() - cycle_t0) * 1000.0);
         }
-        ds4_mtp_accept_gate_record(s, 0, draft_n);
+        ds4_mtp_accept_gate_record(s, 0, draft_n, stats);
         ds4_mtp_accept_trace(s, "first-miss", cycle_start,
                              first_token, drafts, draft_n, n_accept);
         return n_accept;
@@ -40472,7 +40482,10 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         getenv("DS4_MTP_PRESERVE_TARGET_FRONTIER") != NULL;
     if (preserve_target_frontier && draft_cap > 1) {
         have_draft_frontier = spec_frontier_snapshot(&draft_frontier, s);
-        if (!have_draft_frontier) return n_accept;
+        if (!have_draft_frontier) {
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
+            return n_accept;
+        }
     }
     for (; draft_n < draft_cap; draft_n++) {
         ds4_gpu_tensor *prev_hc = (draft_n & 1) ? s->graph.mtp_state_hc : s->graph.mtp_next_hc;
@@ -40499,6 +40512,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                 s->graph.mtp_n_raw = mtp_n_raw_after_draft;
                 spec_frontier_free(&draft_frontier);
             }
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return n_accept;
         }
         if (mtp_fast_top2) mtp_last_top2 = mtp_top2;
@@ -40514,6 +40528,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             spec_frontier_free(&draft_frontier);
             snprintf(err, errlen, "MTP draft frontier restore failed");
             s->checkpoint_valid = false;
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return -1;
         }
         s->graph.mtp_n_raw = mtp_n_raw_after_draft;
@@ -40550,6 +40565,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                 free(row_logits);
                 snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
                 s->checkpoint_valid = false;
+                if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
                 return -1;
             }
             memcpy(s->logits, row_logits, (size_t)DS4_N_VOCAB * sizeof(s->logits[0]));
@@ -40578,7 +40594,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                         (done - mtp_t0) * 1000.0,
                         (done - cycle_t0) * 1000.0);
             }
-            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
             ds4_mtp_accept_trace(s, "margin-skip", cycle_start,
                                  first_token, drafts, draft_n, n_accept);
             return n_accept;
@@ -40637,6 +40653,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         if (!ok) {
             snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return -1;
         }
         s->checkpoint_valid = true;
@@ -40661,7 +40678,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     (done - mtp_t0) * 1000.0,
                     (done - cycle_t0) * 1000.0);
         }
-        ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+        ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
         ds4_mtp_accept_trace(s, "exact-seq", cycle_start,
                              first_token, drafts, draft_n, n_accept);
         return n_accept;
@@ -40718,7 +40735,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             spec_frontier_free(&frontier);
             free(row0_logits);
             free(row_logits);
-            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
             ds4_mtp_accept_trace(s, "decode2", cycle_start,
                                  first_token, drafts, draft_n, n_accept);
             return n_accept;
@@ -40754,7 +40771,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             spec_frontier_free(&frontier);
             free(row0_logits);
             free(row_logits);
-            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+            ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
             ds4_mtp_accept_trace(s, "decode2", cycle_start,
                                  first_token, drafts, draft_n, n_accept);
             return n_accept;
@@ -41139,7 +41156,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                         free(shadow_exact_logits0);
                         free(shadow_exact_logits1);
                         free(row_tops);
-                        ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                        ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                         ds4_mtp_accept_trace(s, "micro-exact-replay-debug", cycle_start,
                                              first_token, drafts, draft_n, n_accept);
                         return n_accept;
@@ -41187,7 +41204,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     free(shadow_exact_logits0);
                     free(shadow_exact_logits1);
                     free(row_tops);
-                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                     ds4_mtp_accept_trace(s, "micro", cycle_start,
                                          first_token, drafts, draft_n, n_accept);
                     return n_accept;
@@ -41239,7 +41256,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     free(shadow_exact_logits0);
                     free(shadow_exact_logits1);
                     free(row_tops);
-                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                     ds4_mtp_accept_trace(s, "verify-v2-decode3", cycle_start,
                                          first_token, drafts, draft_n, n_accept);
                     return n_accept;
@@ -41282,7 +41299,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     free(shadow_exact_logits0);
                     free(shadow_exact_logits1);
                     free(row_tops);
-                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                     ds4_mtp_accept_trace(s, "micro-prefix", cycle_start,
                                          first_token, drafts, draft_n, n_accept);
                     return n_accept;
@@ -41332,7 +41349,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     free(shadow_exact_logits0);
                     free(shadow_exact_logits1);
                     free(row_tops);
-                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                     ds4_mtp_accept_trace(s, "micro-exact-replay", cycle_start,
                                          first_token, drafts, draft_n, n_accept);
                     return n_accept;
@@ -41390,7 +41407,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     free(shadow_exact_logits0);
                     free(shadow_exact_logits1);
                     free(row_tops);
-                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+                    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
                     ds4_mtp_accept_trace(s, "micro-replay", cycle_start,
                                          first_token, drafts, draft_n, n_accept);
                     return n_accept;
@@ -41413,6 +41430,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
             free(shadow_exact_logits0);
             free(shadow_exact_logits1);
             free(row_tops);
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return -1;
         }
         spec_frontier_free(&frontier);
@@ -41461,6 +41479,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         if (!_ver_raw_ok) {
             snprintf(err, errlen, "%s decode failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return -1;
         }
         token_vec_push(&s->checkpoint, drafts[i]);
@@ -41477,6 +41496,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
         {
             snprintf(err, errlen, "%s logits readback failed", ds4_backend_name(e->backend));
             s->checkpoint_valid = false;
+            if (stats) { stats->drafted = draft_n; stats->accepted = n_accept - 1; }
             return -1;
         }
         logits_on_host = true;
@@ -41515,7 +41535,7 @@ int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                     n_accept);
         }
     }
-    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n);
+    ds4_mtp_accept_gate_record(s, n_accept - 1, draft_n, stats);
     ds4_mtp_accept_trace(s, "seq", cycle_start,
                          first_token, drafts, draft_n, n_accept);
     return n_accept;

--- a/ds4.h
+++ b/ds4.h
@@ -724,9 +724,20 @@ int ds4_session_token_logprob(ds4_session *s, int token, ds4_token_score *out);
 int ds4_session_copy_logits(ds4_session *s, float *out, int cap);
 int ds4_session_set_logits(ds4_session *s, const float *logits, int n);
 int ds4_session_eval(ds4_session *s, int token, char *err, size_t errlen);
+/* Per-call speculative-decode accounting for the serial path.  `drafted` is
+ * the number of MTP draft tokens proposed (including the first proposed
+ * draft), and `accepted` is the number of those drafts that were verified and
+ * committed (the unconditionally committed first_token is NOT counted).
+ * Mirrors the batch path's ds4_cont_seq_stats.spec_drafts/spec_hits. */
+typedef struct {
+    int drafted;
+    int accepted;
+} ds4_spec_stats;
+
 int ds4_session_eval_speculative_argmax(ds4_session *s, int first_token,
                                         int max_tokens, int eos_token,
                                         int *accepted, int accepted_cap,
+                                        ds4_spec_stats *stats,
                                         char *err, size_t errlen);
 void ds4_session_invalidate(ds4_session *s);
 void ds4_session_rewind(ds4_session *s, int pos);

--- a/ds4_bench.c
+++ b/ds4_bench.c
@@ -675,7 +675,7 @@ int main(int argc, char **argv) {
                                                                eos,
                                                                toks,
                                                                (int)(sizeof(toks) / sizeof(toks[0])),
-                                                               err,
+                                                               NULL, err,
                                                                sizeof(err));
                 if (ntok < 0) {
                     fprintf(stderr, "ds4-bench: speculative decode at frontier %d failed: %s\n", frontier, err);

--- a/ds4_cli.c
+++ b/ds4_cli.c
@@ -620,7 +620,7 @@ static int run_sampled_generation(ds4_engine *engine, const cli_config *cfg, con
                                                        ds4_token_eos(engine),
                                                        toks,
                                                        (int)(sizeof(toks) / sizeof(toks[0])),
-                                                       err,
+                                                       NULL, err,
                                                        sizeof(err));
             cli_dist_busy_set(cfg, false);
             if (ntok < 0) {
@@ -1376,7 +1376,7 @@ static int run_chat_turn(ds4_engine *engine, cli_config *cfg, repl_chat *chat, c
                                                        ds4_token_eos(engine),
                                                        toks,
                                                        (int)(sizeof(toks) / sizeof(toks[0])),
-                                                       err,
+                                                       NULL, err,
                                                        sizeof(err));
             cli_dist_busy_set(cfg, false);
             if (ntok < 0) {

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -5201,21 +5201,28 @@ static void append_timings_json(buf *b, const request *r) {
     const req_timings *t = r ? &r->timings : NULL;
     if (!t || !t->valid) return;
     /* llama.cpp-compatible fields (llama-swap webui reads these): prompt_n =
-     * total prompt tokens, predicted_n = generated tokens, cache_n = cached
-     * prompt tokens, prompt_ms/predicted_ms already ms-converted (never raw
-     * seconds), and per-second fields derived from those ms values as
-     * tokens / (ms / 1e3).  Zero-duration inputs emit 0.0 with no
-     * division-by-zero.  predicted_n counts every accepted token because
-     * decode_tokens = acc.completion, and sem_accum_feed increments
-     * a->completion once per accepted token (drafted or sampled), so the
-     * reported throughput is draft-inclusive. */
-    const double prompt_n = (double)(t->prefill_tokens + t->prefill_cached);
+     * newly computed prompt tokens only (cache excluded; the cached prefix is
+     * reported separately via cache_n, and prompt_n + cache_n still equals
+     * OpenAI usage's total prompt_tokens), predicted_n = generated tokens,
+     * prompt_ms/predicted_ms already ms-converted (never raw seconds).
+     * Per-second fields are derived from those ms values as tokens /
+     * (ms / 1e3): prompt_per_second is the computed-only prompt rate
+     * (== prefill_tok_s), and predicted_per_second excludes the free first
+     * token like llama.cpp's n_gen_steps() (== decode_tok_s); both guard
+     * non-positive divisors/nominators and emit 0.0 instead of dividing.
+     * predicted_n counts every accepted token because decode_tokens =
+     * acc.completion, and sem_accum_feed increments a->completion once per
+     * accepted token (drafted or sampled), so the reported throughput is
+     * draft-inclusive. */
+    const double prompt_n = (double)t->prefill_tokens;
     const double predicted_n = (double)t->decode_tokens;
     const double cache_n = (double)t->prefill_cached;
     const double prompt_per_second =
         t->prefill_ms > 0.0 ? prompt_n / (t->prefill_ms / 1e3) : 0.0;
     const double predicted_per_second =
-        t->decode_ms > 0.0 ? predicted_n / (t->decode_ms / 1e3) : 0.0;
+        t->decode_tokens > 1 && t->decode_ms > 0.0
+            ? (t->decode_tokens - 1) / (t->decode_ms / 1e3)
+            : 0.0;
 
     buf_printf(b, ",\"timings\":{\"ttft_ms\":%.1f,\"prefill_tokens\":%d,"
                   "\"prefill_cached_tokens\":%d"
@@ -18940,13 +18947,13 @@ static void test_timings_block_renders_next_to_usage(void) {
     TEST_ASSERT(strstr(out, "\"timings\":{\"ttft_ms\":812.5") != NULL);
     TEST_ASSERT(strstr(out, "\"prefill_tokens\":1000") != NULL);
     TEST_ASSERT(strstr(out, "\"prefill_cached_tokens\":24") != NULL);
-    TEST_ASSERT(strstr(out, "\"prompt_n\":1024") != NULL);          /* 1000 + 24 */
+    TEST_ASSERT(strstr(out, "\"prompt_n\":1000") != NULL);          /* computed-only; +24 in cache_n */
     TEST_ASSERT(strstr(out, "\"predicted_n\":101") != NULL);
     TEST_ASSERT(strstr(out, "\"cache_n\":24") != NULL);
     TEST_ASSERT(strstr(out, "\"prompt_ms\":500.0") != NULL);
     TEST_ASSERT(strstr(out, "\"predicted_ms\":2000.0") != NULL);
-    TEST_ASSERT(strstr(out, "\"prompt_per_second\":2048.00") != NULL); /* 1024/(500ms) */
-    TEST_ASSERT(strstr(out, "\"predicted_per_second\":50.50") != NULL); /* 101/(2000ms) */
+    TEST_ASSERT(strstr(out, "\"prompt_per_second\":2000.00") != NULL); /* 1000/(500ms) */
+    TEST_ASSERT(strstr(out, "\"predicted_per_second\":50.00") != NULL); /* (101-1)/(2000ms) */
     TEST_ASSERT(strstr(out, "\"prefill_tok_s\":2000.0") != NULL);
     TEST_ASSERT(strstr(out, "\"decode_tok_s\":50.0") != NULL);
     TEST_ASSERT(strstr(out, "\"spec_accept_rate\":0.800") != NULL);
@@ -18966,6 +18973,45 @@ static void test_timings_block_renders_next_to_usage(void) {
     out = read_socket_text(sv[1]);
     TEST_ASSERT(strstr(out, "\"timings\":{") != NULL);
     TEST_ASSERT(strstr(out, "spec_accept_rate") == NULL);
+    free(out);
+    close(sv[0]);
+    close(sv[1]);
+
+    /* Warm-cache hit: prompt_n is computed-only (the cached prefix rides in
+     * cache_n), so prompt_per_second equals the computed-only rate
+     * (prefill_tok_s), not the total-token rate. */
+    r.timings.prefill_tokens = 9;
+    r.timings.prefill_cached = 14059;
+    r.timings.prefill_ms = 187.7;
+    TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    TEST_ASSERT(sse_done(sv[0], &r, "chatcmpl_timings_warm", 14068, 101));
+    shutdown(sv[0], SHUT_WR);
+    out = read_socket_text(sv[1]);
+    TEST_ASSERT(strstr(out, "\"prompt_tokens\":14068") != NULL); /* usage keeps the total */
+    TEST_ASSERT(strstr(out, "\"prefill_tokens\":9") != NULL);
+    TEST_ASSERT(strstr(out, "\"prefill_cached_tokens\":14059") != NULL);
+    TEST_ASSERT(strstr(out, "\"prompt_n\":9") != NULL);
+    TEST_ASSERT(strstr(out, "\"cache_n\":14059") != NULL);
+    char computed_rate[64];
+    snprintf(computed_rate, sizeof(computed_rate), "\"prompt_per_second\":%.2f",
+             (double)r.timings.prefill_tokens / (r.timings.prefill_ms / 1e3));
+    TEST_ASSERT(strstr(out, computed_rate) != NULL); /* 47.95 == prefill rate */
+    TEST_ASSERT(strstr(out, "\"prefill_tok_s\":47.9") != NULL);
+    free(out);
+    close(sv[0]);
+    close(sv[1]);
+
+    /* Single decoded token: predicted_per_second is 0.0 (the first token is
+     * free), matching llama.cpp's n_gen_steps() == 0. */
+    r.timings.decode_tokens = 1;
+    r.timings.decode_ms = 1000.0;
+    TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    TEST_ASSERT(sse_done(sv[0], &r, "chatcmpl_timings_one", 14068, 1));
+    shutdown(sv[0], SHUT_WR);
+    out = read_socket_text(sv[1]);
+    TEST_ASSERT(strstr(out, "\"predicted_n\":1") != NULL);
+    TEST_ASSERT(strstr(out, "\"predicted_per_second\":0.00") != NULL);
+    TEST_ASSERT(strstr(out, "decode_tok_s") == NULL);
     free(out);
     close(sv[0]);
     close(sv[1]);

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -5232,9 +5232,15 @@ static void append_timings_json(buf *b, const request *r) {
     if (t->decode_tokens > 1 && t->decode_ms > 0.0)
         buf_printf(b, ",\"decode_tok_s\":%.1f",
                    (double)(t->decode_tokens - 1) / (t->decode_ms / 1e3));
-    if (t->spec_drafts > 0)
-        buf_printf(b, ",\"spec_accept_rate\":%.3f",
+    if (t->spec_drafts > 0) {
+        /* llama-swap's ActivityTable "Drafted" column reads draft_n /
+         * draft_n_accepted (llama.cpp-server keys); spec_accept_rate is an
+         * extra derived convenience field. */
+        buf_printf(b, ",\"draft_n\":%lld,\"draft_n_accepted\":%lld"
+                      ",\"spec_accept_rate\":%.3f",
+                   t->spec_drafts, t->spec_hits,
                    (double)t->spec_hits / (double)t->spec_drafts);
+    }
     if (t->decode_steps > 0)
         buf_printf(b, ",\"tok_per_step\":%.2f",
                    (double)t->decode_tokens / (double)t->decode_steps);
@@ -12363,6 +12369,8 @@ static void generate_job(server *s, job *j) {
      * decode_again tool-recovery rerun; timings reflect the full request). */
     double t_first_tok = 0.0;
     int serial_decode_steps = 0;
+    int serial_spec_drafts = 0;
+    int serial_spec_hits = 0;
 decode_again:
     ;
     /* Inc 7a: ALL per-token semantic state lives in the shared accumulator;
@@ -12427,14 +12435,24 @@ decode_again:
             ds4_engine_mtp_draft_tokens(s->engine) > 1 &&
             getenv("DS4_MTP_SPEC_DISABLE") == NULL)
         {
+            ds4_spec_stats stats = {0};
             ntok = ds4_session_eval_speculative_argmax(s->session,
                                                        token,
                                                        max_tokens - acc.completion,
                                                        ds4_token_eos(s->engine),
                                                        toks,
                                                        (int)(sizeof(toks) / sizeof(toks[0])),
-                                                       err,
+                                                       &stats, err,
                                                        sizeof(err));
+            serial_spec_drafts += stats.drafted;
+            serial_spec_hits += stats.accepted;
+            /* v0.2.x observability: feed the global speculation counters so the
+             * /v1/stats "Drafted"/"Hits" board (and Prometheus totals) reflect the
+             * serial path too -- mirrors ds4.c:36599. */
+            if (stats.drafted) ds4_metric_add(&ds4_metrics_get()->spec_drafts,
+                                              (uint64_t)stats.drafted);
+            if (stats.accepted) ds4_metric_add(&ds4_metrics_get()->spec_hits,
+                                               (uint64_t)stats.accepted);
             if (ntok < 0) {
                 finish = "error";
                 break;
@@ -12934,6 +12952,8 @@ decode_again:
         t->prefill_cached = cached;
         t->decode_tokens = acc.completion;
         t->decode_steps = serial_decode_steps;
+        t->spec_drafts = serial_spec_drafts;
+        t->spec_hits = serial_spec_hits;
     }
 
     {

--- a/ds4_server.c
+++ b/ds4_server.c
@@ -5200,9 +5200,32 @@ static void append_openai_usage_json(buf *b, const request *r,
 static void append_timings_json(buf *b, const request *r) {
     const req_timings *t = r ? &r->timings : NULL;
     if (!t || !t->valid) return;
+    /* llama.cpp-compatible fields (llama-swap webui reads these): prompt_n =
+     * total prompt tokens, predicted_n = generated tokens, cache_n = cached
+     * prompt tokens, prompt_ms/predicted_ms already ms-converted (never raw
+     * seconds), and per-second fields derived from those ms values as
+     * tokens / (ms / 1e3).  Zero-duration inputs emit 0.0 with no
+     * division-by-zero.  predicted_n counts every accepted token because
+     * decode_tokens = acc.completion, and sem_accum_feed increments
+     * a->completion once per accepted token (drafted or sampled), so the
+     * reported throughput is draft-inclusive. */
+    const double prompt_n = (double)(t->prefill_tokens + t->prefill_cached);
+    const double predicted_n = (double)t->decode_tokens;
+    const double cache_n = (double)t->prefill_cached;
+    const double prompt_per_second =
+        t->prefill_ms > 0.0 ? prompt_n / (t->prefill_ms / 1e3) : 0.0;
+    const double predicted_per_second =
+        t->decode_ms > 0.0 ? predicted_n / (t->decode_ms / 1e3) : 0.0;
+
     buf_printf(b, ",\"timings\":{\"ttft_ms\":%.1f,\"prefill_tokens\":%d,"
-                  "\"prefill_cached_tokens\":%d",
-               t->ttft_ms, t->prefill_tokens, t->prefill_cached);
+                  "\"prefill_cached_tokens\":%d"
+                  ",\"prompt_n\":%.0f,\"predicted_n\":%.0f,\"cache_n\":%.0f"
+                  ",\"prompt_ms\":%.1f,\"predicted_ms\":%.1f"
+                  ",\"prompt_per_second\":%.2f,\"predicted_per_second\":%.2f",
+               t->ttft_ms, t->prefill_tokens, t->prefill_cached,
+               prompt_n, predicted_n, cache_n,
+               t->prefill_ms, t->decode_ms,
+               prompt_per_second, predicted_per_second);
     if (t->prefill_tokens > 0 && t->prefill_ms > 0.0)
         buf_printf(b, ",\"prefill_tok_s\":%.1f",
                    (double)t->prefill_tokens / (t->prefill_ms / 1e3));
@@ -18897,6 +18920,13 @@ static void test_timings_block_renders_next_to_usage(void) {
     TEST_ASSERT(strstr(out, "\"timings\":{\"ttft_ms\":812.5") != NULL);
     TEST_ASSERT(strstr(out, "\"prefill_tokens\":1000") != NULL);
     TEST_ASSERT(strstr(out, "\"prefill_cached_tokens\":24") != NULL);
+    TEST_ASSERT(strstr(out, "\"prompt_n\":1024") != NULL);          /* 1000 + 24 */
+    TEST_ASSERT(strstr(out, "\"predicted_n\":101") != NULL);
+    TEST_ASSERT(strstr(out, "\"cache_n\":24") != NULL);
+    TEST_ASSERT(strstr(out, "\"prompt_ms\":500.0") != NULL);
+    TEST_ASSERT(strstr(out, "\"predicted_ms\":2000.0") != NULL);
+    TEST_ASSERT(strstr(out, "\"prompt_per_second\":2048.00") != NULL); /* 1024/(500ms) */
+    TEST_ASSERT(strstr(out, "\"predicted_per_second\":50.50") != NULL); /* 101/(2000ms) */
     TEST_ASSERT(strstr(out, "\"prefill_tok_s\":2000.0") != NULL);
     TEST_ASSERT(strstr(out, "\"decode_tok_s\":50.0") != NULL);
     TEST_ASSERT(strstr(out, "\"spec_accept_rate\":0.800") != NULL);
@@ -18916,6 +18946,19 @@ static void test_timings_block_renders_next_to_usage(void) {
     out = read_socket_text(sv[1]);
     TEST_ASSERT(strstr(out, "\"timings\":{") != NULL);
     TEST_ASSERT(strstr(out, "spec_accept_rate") == NULL);
+    free(out);
+    close(sv[0]);
+    close(sv[1]);
+
+    /* Zero-duration timings: per-second fields emit 0.0, no div-by-zero. */
+    r.timings.prefill_ms = 0.0;
+    r.timings.decode_ms = 0.0;
+    TEST_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+    TEST_ASSERT(sse_done(sv[0], &r, "chatcmpl_timings3", 1024, 101));
+    shutdown(sv[0], SHUT_WR);
+    out = read_socket_text(sv[1]);
+    TEST_ASSERT(strstr(out, "\"prompt_per_second\":0.00") != NULL);
+    TEST_ASSERT(strstr(out, "\"predicted_per_second\":0.00") != NULL);
     free(out);
     close(sv[0]);
     close(sv[1]);


### PR DESCRIPTION
Thanks a ton for making this beautiful solution for DGX owners! 
Even with Q2SS DS4 0731 is very powerful. 

I took some time to throw up a simple MR with added support for proper timings report to llama-swap, including the amount of drafted tokens. These are still gated by include_usage in ds4 core, so in llama-swap you will have to add a filter: 

```
    filters:
      setParams:
        stream_options.include_usage: true
```  
so that all responses get proper metrics. And if all goes well, you'll see something like this: 

<img width="1567" height="355" alt="image" src="https://github.com/user-attachments/assets/8539b595-0f01-47b9-9528-2eeece25c428" />

I'm not sure which branch is current dev tip, I forked off batch-serving, since it seemed to contain latest release tag. 

**AI Disclosure:** Used openspec + DeepSeek V4 Flash 0731 running from this very ds4 fork to make these 2 patches, as the very first 'not so easy' task for it.  Surprisingly the result was not too ugly and worked almost from the first attempt.  